### PR TITLE
Include isotropic/anisotropic kernel type in model printouts

### DIFF
--- a/R/print_BKP.R
+++ b/R/print_BKP.R
@@ -102,7 +102,8 @@ print.BKP <- function(x, ...) {
   cat("\n       Beta Kernel Process (BKP) Model    \n\n")
   cat(sprintf("Number of observations (n):  %d\n", nrow(x$X)))
   cat(sprintf("Input dimensionality (d):    %d\n", ncol(x$X)))
-  cat(sprintf("Kernel type:                 %s\n", x$kernel))
+  kernel_variant <- if (isTRUE(x$isotropic)) "isotropic" else "anisotropic"
+  cat(sprintf("Kernel type:                 %s %s\n", kernel_variant, x$kernel))
   cat(sprintf("Optimized kernel parameters: %s\n",
               paste(sprintf("%.4f", x$theta_opt), collapse = ", ")))
   cat(sprintf("Minimum achieved loss:       %.5f\n", x$loss_min))
@@ -129,7 +130,8 @@ print.summary_BKP <- function(x, ...) {
   cat("\n       Beta Kernel Process (BKP) Model   \n\n")
   cat(sprintf("Number of observations (n):  %d\n", x$n_obs))
   cat(sprintf("Input dimensionality (d):    %d\n", x$input_dim))
-  cat(sprintf("Kernel type:                 %s\n", x$kernel))
+  kernel_variant <- if (isTRUE(x$isotropic)) "isotropic" else "anisotropic"
+  cat(sprintf("Kernel type:                 %s %s\n", kernel_variant, x$kernel))
   cat(sprintf("Optimized kernel parameters: %s\n",
               paste(sprintf("%.4f", x$theta_opt), collapse = ", ")))
   cat(sprintf("Minimum achieved loss:       %.5f\n", x$loss_min))

--- a/R/print_DKP.R
+++ b/R/print_DKP.R
@@ -77,7 +77,8 @@ print.DKP <- function(x, ...) {
   cat(sprintf("Number of observations (n):  %d\n", nrow(x$X)))
   cat(sprintf("Input dimensionality (d):    %d\n", ncol(x$X)))
   cat(sprintf("Number of classes (q):       %d\n", ncol(x$Y)))
-  cat(sprintf("Kernel type:                 %s\n", x$kernel))
+  kernel_variant <- if (isTRUE(x$isotropic)) "isotropic" else "anisotropic"
+  cat(sprintf("Kernel type:                 %s %s\n", kernel_variant, x$kernel))
   cat(sprintf("Optimized kernel parameters: %s\n",
               paste(sprintf("%.4f", x$theta_opt), collapse = ", ")))
   cat(sprintf("Minimum achieved loss:       %.5f\n", x$loss_min))
@@ -105,7 +106,8 @@ print.summary_DKP <- function(x, ...) {
   cat(sprintf("Number of observations (n):  %d\n", x$n_obs))
   cat(sprintf("Input dimensionality (d):    %d\n", x$input_dim))
   cat(sprintf("Number of classes (q):       %d\n", x$n_class))
-  cat(sprintf("Kernel type:                 %s\n", x$kernel))
+  kernel_variant <- if (isTRUE(x$isotropic)) "isotropic" else "anisotropic"
+  cat(sprintf("Kernel type:                 %s %s\n", kernel_variant, x$kernel))
   cat(sprintf("Optimized kernel parameters: %s\n",
               paste(sprintf("%.4f", x$theta_opt), collapse = ", ")))
   cat(sprintf("Minimum achieved loss:       %.5f\n", x$loss_min))

--- a/R/summary_BKP.R
+++ b/R/summary_BKP.R
@@ -112,6 +112,7 @@ summary.BKP <- function(object, ...) {
     n_obs       = n_obs,
     input_dim   = d,
     kernel      = object$kernel,
+    isotropic   = object$isotropic,
     theta_opt   = object$theta_opt,
     loss        = object$loss,
     loss_min    = object$loss_min,

--- a/R/summary_DKP.R
+++ b/R/summary_DKP.R
@@ -85,6 +85,7 @@ summary.DKP <- function(object, ...) {
     input_dim = d,
     n_class   = q,
     kernel    = object$kernel,
+    isotropic = object$isotropic,
     theta_opt = object$theta_opt,
     loss      = object$loss,
     loss_min  = object$loss_min,

--- a/tests/testthat/test-summary_BKP.R
+++ b/tests/testthat/test-summary_BKP.R
@@ -40,7 +40,7 @@ test_that("summary.BKP returns a well-structured summary object with correct val
   expect_s3_class(summary_obj, "summary_BKP")
 
   # Check for all expected named elements
-  expected_names <- c("n_obs", "input_dim", "kernel", "theta_opt", "loss",
+  expected_names <- c("n_obs", "input_dim", "kernel", "isotropic", "theta_opt", "loss",
                       "loss_min", "prior", "r0", "p0", "post_mean", "post_var")
   expect_named(summary_obj, expected_names)
 
@@ -54,6 +54,7 @@ test_that("summary.BKP returns a well-structured summary object with correct val
 
   # Dynamically check kernel and loss type from the fitted model object
   expect_equal(summary_obj$kernel, model$kernel)
+  expect_equal(summary_obj$isotropic, model$isotropic)
   expect_equal(summary_obj$loss, model$loss)
 
   # Check if theta_opt is a numeric vector

--- a/tests/testthat/test-summary_DKP.R
+++ b/tests/testthat/test-summary_DKP.R
@@ -46,7 +46,7 @@ test_that("summary.DKP returns a well-structured summary object with correct val
 
   # Check for all expected named elements, adjusted for the current function's output
   # NOTE: The test now expects 'n_class' instead of 'output_dim'
-  expected_names <- c("n_obs", "input_dim", "n_class", "kernel", "theta_opt", "loss",
+  expected_names <- c("n_obs", "input_dim", "n_class", "kernel", "isotropic", "theta_opt", "loss",
                       "loss_min", "prior", "r0", "p0", "post_mean", "post_var")
   expect_named(summary_obj, expected_names)
 
@@ -62,6 +62,7 @@ test_that("summary.DKP returns a well-structured summary object with correct val
 
   # Dynamically check kernel and loss type from the fitted model object
   expect_equal(summary_obj$kernel, model$kernel)
+  expect_equal(summary_obj$isotropic, model$isotropic)
   expect_equal(summary_obj$loss, model$loss)
 
   # Check if theta_opt is a numeric vector


### PR DESCRIPTION
### Motivation
- Make the kernel output in model `print`/`summary` human-readable by explicitly indicating whether the lengthscale parameterization is `isotropic` or `anisotropic` along with the kernel name.
- Ensure `summary` objects contain the `isotropic` flag so summary print methods can report kernel isotropy consistently and tests can validate it.

### Description
- Updated `print.BKP` and `print.summary_BKP` in `R/print_BKP.R` to compute `kernel_variant <- if (isTRUE(x$isotropic)) "isotropic" else "anisotropic"` and print `kernel_variant` followed by `x$kernel` for the `Kernel type:` line.
- Updated `print.DKP` and `print.summary_DKP` in `R/print_DKP.R` to use the same `kernel_variant` logic and format the `Kernel type:` line as `<isotropic|anisotropic> <kernel>`.
- Added `isotropic = object$isotropic` to the returned lists in `summary.BKP` (`R/summary_BKP.R`) and `summary.DKP` (`R/summary_DKP.R`) so summaries expose the isotropy flag.
- Updated tests `tests/testthat/test-summary_BKP.R` and `tests/testthat/test-summary_DKP.R` to expect the new `isotropic` element in the summary objects and to assert it matches `model$isotropic`.

### Testing
- Attempted to run the targeted `testthat` files (`test-summary_BKP.R`, `test-summary_DKP.R`, `test-print_BKP.R`, `test-print_DKP.R`) using `Rscript`, but `Rscript` is not available in this environment so the tests could not be executed.
- Updated unit tests in the repository to reflect the new `isotropic` field and assertions, but no automated test results are available from this run due to the missing `Rscript` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a6d1c7d483209a248484dca27528)