### PR TITLE
Add `engine` option to `plot.BKP`/`plot.DKP` with optional ggplot2 backend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,6 @@ NeedsCompilation: no
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Depends: R (>= 3.5.0)
-Imports: dirmult, gridExtra, lattice, optimx, tgp
+Imports: dirmult, ggplot2, gridExtra, lattice, optimx, tgp
 Suggests: knitr, mlbench, testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/plot_BKP.R
+++ b/R/plot_BKP.R
@@ -20,6 +20,9 @@
 #' @param dims Integer vector indicating which input dimensions to plot. Must
 #'   have length 1 (for 1D) or 2 (for 2D). If \code{NULL} (default), all
 #'   dimensions are used when their number is <= 2.
+#' @param engine Character string specifying plotting backend for 2D plots.
+#'   Either \code{"base"} (default, lattice-based output) or
+#'   \code{"ggplot"}.
 #' @param ... Additional arguments passed to internal plotting routines
 #'   (currently unused).
 #'
@@ -133,7 +136,7 @@
 #' @export
 #' @method plot BKP
 
-plot.BKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
+plot.BKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, engine = "base", ...){
   # ---------------- Argument Checking ----------------
   if (!is.logical(only_mean) || length(only_mean) != 1) {
     stop("`only_mean` must be a single logical value (TRUE or FALSE).")
@@ -143,6 +146,10 @@ plot.BKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
     stop("'n_grid' must be a positive integer.")
   }
   n_grid <- as.integer(n_grid)
+
+  if (!is.character(engine) || length(engine) != 1 || !engine %in% c("base", "ggplot")) {
+    stop("`engine` must be one of c('base', 'ggplot').")
+  }
 
   # Extract necessary components from the BKP model object.
   X <- x$X # Covariate matrix.
@@ -251,28 +258,51 @@ plot.BKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
     if (only_mean) {
       # Only plot the predicted mean graphs
       if(is_classification){
-        p1 <- my_2D_plot_fun("Mean", "Predicted Class Probability (Predictive Mean)", df, X = X_sub, y = y)
+        p1 <- if (engine == "ggplot") {
+          my_2D_plot_fun_ggplot("Mean", "Predicted Class Probability (Predictive Mean)", df, X = X_sub, y = y, dims = dims)
+        } else {
+          my_2D_plot_fun("Mean", "Predicted Class Probability (Predictive Mean)", df, X = X_sub, y = y, dims = dims)
+        }
       }else{
-        p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df)
+        p1 <- if (engine == "ggplot") {
+          my_2D_plot_fun_ggplot("Mean", "Predictive Mean", df, dims = dims)
+        } else {
+          my_2D_plot_fun("Mean", "Predictive Mean", df, dims = dims)
+        }
       }
       print(p1)
     } else {
       # Create 2 or 4 plots
       if(is_classification){
-        p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, X = X_sub, y = y, dims= dims)
-        p3 <- my_2D_plot_fun("Variance", "Predictive Variance", df, X = X_sub, y = y, dims= dims)
+        if (engine == "ggplot") {
+          p1 <- my_2D_plot_fun_ggplot("Mean", "Predictive Mean", df, X = X_sub, y = y, dims = dims)
+          p3 <- my_2D_plot_fun_ggplot("Variance", "Predictive Variance", df, X = X_sub, y = y, dims = dims)
+        } else {
+          p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, X = X_sub, y = y, dims= dims)
+          p3 <- my_2D_plot_fun("Variance", "Predictive Variance", df, X = X_sub, y = y, dims= dims)
+        }
       }else{
-        p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, dims= dims)
-        p3 <- my_2D_plot_fun("Variance", "Predictive Variance", df, dims= dims)
+        if (engine == "ggplot") {
+          p1 <- my_2D_plot_fun_ggplot("Mean", "Predictive Mean", df, dims = dims)
+          p3 <- my_2D_plot_fun_ggplot("Variance", "Predictive Variance", df, dims = dims)
+        } else {
+          p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, dims= dims)
+          p3 <- my_2D_plot_fun("Variance", "Predictive Variance", df, dims= dims)
+        }
       }
       if(is_classification){
         # Arrange into 1×2 layout
-        grid.arrange(p1, p3, ncol = 2)
+        gridExtra::grid.arrange(p1, p3, ncol = 2)
       }else{
-        p2 <- my_2D_plot_fun("Upper", paste0(prediction$CI_level * 100, "% CI Upper"), df, dims= dims)
-        p4 <- my_2D_plot_fun("Lower", paste0(prediction$CI_level * 100, "% CI Lower"), df, dims= dims)
+        if (engine == "ggplot") {
+          p2 <- my_2D_plot_fun_ggplot("Upper", paste0(prediction$CI_level * 100, "% CI Upper"), df, dims = dims)
+          p4 <- my_2D_plot_fun_ggplot("Lower", paste0(prediction$CI_level * 100, "% CI Lower"), df, dims = dims)
+        } else {
+          p2 <- my_2D_plot_fun("Upper", paste0(prediction$CI_level * 100, "% CI Upper"), df, dims= dims)
+          p4 <- my_2D_plot_fun("Lower", paste0(prediction$CI_level * 100, "% CI Lower"), df, dims= dims)
+        }
         # Arrange into 2×2 layout
-        grid.arrange(p1, p2, p3, p4, ncol = 2)
+        gridExtra::grid.arrange(p1, p2, p3, p4, ncol = 2)
       }
     }
   }

--- a/R/plot_DKP.R
+++ b/R/plot_DKP.R
@@ -70,7 +70,7 @@
 #' @export
 #' @method plot DKP
 
-plot.DKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
+plot.DKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, engine = "base", ...){
   # ---------------- Argument Checking ----------------
   if (!is.logical(only_mean) || length(only_mean) != 1) {
     stop("`only_mean` must be a single logical value (TRUE or FALSE).")
@@ -80,6 +80,10 @@ plot.DKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
     stop("'n_grid' must be a positive integer.")
   }
   n_grid <- as.integer(n_grid)
+
+  if (!is.character(engine) || length(engine) != 1 || !engine %in% c("base", "ggplot")) {
+    stop("`engine` must be one of c('base', 'ggplot').")
+  }
 
   # Extract necessary components from the DKP model object.
   X <- x$X # Covariate matrix.
@@ -218,9 +222,14 @@ plot.DKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
                        class = factor(prediction$class),
                        max_prob = apply(prediction$mean, 1, max))
 
-      p1 <- my_2D_plot_fun_class("class", "Predicted Classes", df, X_sub, Y, dims= dims)
-      p2 <- my_2D_plot_fun_class("max_prob", "Maximum Predicted Probability", df, X_sub, Y, classification = FALSE, dims= dims)
-      grid.arrange(p1, p2, ncol = 2)
+      if (engine == "ggplot") {
+        p1 <- my_2D_plot_fun_class_ggplot("class", "Predicted Classes", df, X_sub, Y, dims = dims)
+        p2 <- my_2D_plot_fun_class_ggplot("max_prob", "Maximum Predicted Probability", df, X_sub, Y, classification = FALSE, dims = dims)
+      } else {
+        p1 <- my_2D_plot_fun_class("class", "Predicted Classes", df, X_sub, Y, dims= dims)
+        p2 <- my_2D_plot_fun_class("max_prob", "Maximum Predicted Probability", df, X_sub, Y, classification = FALSE, dims= dims)
+      }
+      gridExtra::grid.arrange(p1, p2, ncol = 2)
     }else{
       for (j in 1:q) {
         df <- data.frame(x1 = grid$x1, x2 = grid$x2,
@@ -231,16 +240,27 @@ plot.DKP <- function(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...){
 
         if (only_mean) {
           # Only plot the predicted mean graphs
-          p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, dims= dims)
+          p1 <- if (engine == "ggplot") {
+            my_2D_plot_fun_ggplot("Mean", "Predictive Mean", df, dims = dims)
+          } else {
+            my_2D_plot_fun("Mean", "Predictive Mean", df, dims= dims)
+          }
           print(p1)
         } else {
           # Create 4 plots
-          p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, dims= dims)
-          p2 <- my_2D_plot_fun("Upper", paste0(prediction$CI_level * 100, "% CI Upper"), df, dims= dims)
-          p3 <- my_2D_plot_fun("Variance", "Predictive Variance", df, dims= dims)
-          p4 <- my_2D_plot_fun("Lower", paste0(prediction$CI_level * 100, "% CI Lower"), df, dims= dims)
+          if (engine == "ggplot") {
+            p1 <- my_2D_plot_fun_ggplot("Mean", "Predictive Mean", df, dims = dims)
+            p2 <- my_2D_plot_fun_ggplot("Upper", paste0(prediction$CI_level * 100, "% CI Upper"), df, dims = dims)
+            p3 <- my_2D_plot_fun_ggplot("Variance", "Predictive Variance", df, dims = dims)
+            p4 <- my_2D_plot_fun_ggplot("Lower", paste0(prediction$CI_level * 100, "% CI Lower"), df, dims = dims)
+          } else {
+            p1 <- my_2D_plot_fun("Mean", "Predictive Mean", df, dims= dims)
+            p2 <- my_2D_plot_fun("Upper", paste0(prediction$CI_level * 100, "% CI Upper"), df, dims= dims)
+            p3 <- my_2D_plot_fun("Variance", "Predictive Variance", df, dims= dims)
+            p4 <- my_2D_plot_fun("Lower", paste0(prediction$CI_level * 100, "% CI Lower"), df, dims= dims)
+          }
           # Arrange into 2×2 layout
-          grid.arrange(p1, p2, p3, p4, ncol = 2,
+          gridExtra::grid.arrange(p1, p2, p3, p4, ncol = 2,
                        top = textGrob(paste0("Estimated Probability (Class ", j, ")"),
                                       gp = gpar(fontface = "bold", fontsize = 16)))
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,6 +59,68 @@ my_2D_plot_fun_class <- function(var, title, data, X, Y, classification = TRUE, 
   )
 }
 
+my_2D_plot_fun_ggplot <- function(var, title, data, X = NULL, y = NULL, dims = NULL, ...) {
+  p <- ggplot2::ggplot(data, ggplot2::aes(x = x1, y = x2)) +
+    ggplot2::geom_raster(ggplot2::aes_string(fill = var)) +
+    ggplot2::geom_contour(ggplot2::aes_string(z = var), color = "black", linewidth = 0.2) +
+    ggplot2::scale_fill_viridis_c(option = "plasma") +
+    ggplot2::labs(
+      title = title,
+      x = ifelse(is.null(dims), "x1", paste0("x", dims[1])),
+      y = ifelse(is.null(dims), "x2", paste0("x", dims[2])),
+      fill = var
+    ) +
+    ggplot2::theme_minimal()
+
+  if (!is.null(X) && !is.null(y)) {
+    obs_df <- data.frame(
+      x1 = X[, 1],
+      x2 = X[, 2],
+      cls = factor(ifelse(y == 1, "1", "0"))
+    )
+    p <- p +
+      ggplot2::geom_point(data = obs_df,
+                          ggplot2::aes(x = x1, y = x2, shape = cls),
+                          color = "red", size = 2, inherit.aes = FALSE) +
+      ggplot2::scale_shape_manual(values = c("0" = 4, "1" = 16), guide = "none")
+  }
+
+  p
+}
+
+my_2D_plot_fun_class_ggplot <- function(var, title, data, X, Y, classification = TRUE, dims = NULL, ...) {
+  class_Y <- max.col(Y)
+  p <- ggplot2::ggplot(data, ggplot2::aes(x = x1, y = x2))
+
+  if (classification) {
+    p <- p +
+      ggplot2::geom_raster(ggplot2::aes(fill = class), alpha = 0.8) +
+      ggplot2::scale_fill_brewer(palette = "Set2", name = "Class")
+  } else {
+    p <- p +
+      ggplot2::geom_raster(ggplot2::aes_string(fill = var)) +
+      ggplot2::geom_contour(ggplot2::aes_string(z = var), color = "black", linewidth = 0.2) +
+      ggplot2::scale_fill_viridis_c(option = "plasma", direction = -1, name = var)
+  }
+
+  obs_df <- data.frame(x1 = X[, 1], x2 = X[, 2], class = factor(class_Y))
+  p <- p +
+    ggplot2::geom_point(
+      data = obs_df,
+      ggplot2::aes(x = x1, y = x2, shape = class),
+      color = "black", fill = "white", size = 2, stroke = 1,
+      inherit.aes = FALSE
+    ) +
+    ggplot2::labs(
+      title = title,
+      x = ifelse(is.null(dims), "x1", paste0("x", dims[1])),
+      y = ifelse(is.null(dims), "x2", paste0("x", dims[2]))
+    ) +
+    ggplot2::theme_minimal()
+
+  p
+}
+
 posterior_summary <- function(mean_vals, var_vals) {
   summary_mat <- rbind(
     "Posterior means" = c(

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -6,9 +6,9 @@
 \alias{plot.DKP}
 \title{Plot Fitted BKP or DKP Models}
 \usage{
-\method{plot}{BKP}(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...)
+\method{plot}{BKP}(x, only_mean = FALSE, n_grid = 80, dims = NULL, engine = "base", ...)
 
-\method{plot}{DKP}(x, only_mean = FALSE, n_grid = 80, dims = NULL, ...)
+\method{plot}{DKP}(x, only_mean = FALSE, n_grid = 80, dims = NULL, engine = "base", ...)
 }
 \arguments{
 \item{x}{An object of class \code{"BKP"} or \code{"DKP"}, typically returned
@@ -26,6 +26,10 @@ is \code{80}.}
 \item{dims}{Integer vector indicating which input dimensions to plot. Must
 have length 1 (for 1D) or 2 (for 2D). If \code{NULL} (default), all
 dimensions are used when their number is <= 2.}
+
+\item{engine}{Character string specifying plotting backend for 2D plots.
+Either \code{"base"} (default, lattice-based output) or
+\code{"ggplot"}.}
 
 \item{...}{Additional arguments passed to internal plotting routines
 (currently unused).}

--- a/tests/testthat/test-plot_BKP.R
+++ b/tests/testthat/test-plot_BKP.R
@@ -80,3 +80,17 @@ test_that("plot.BKP validates input arguments and classification branches", {
   expect_error(plot(model, dims = c(1, 1)), "`dims` cannot contain duplicate indices")
   expect_error(plot(model, dims = 3), "must be within the range")
 })
+
+
+test_that("plot.BKP supports ggplot engine for 2D and validates engine", {
+  set.seed(2026)
+  skip_if_not_installed("ggplot2")
+
+  X <- matrix(runif(60), ncol = 2)
+  m <- rep(10, nrow(X))
+  y <- rbinom(nrow(X), size = m, prob = 0.5)
+  model <- fit_BKP(X, y, m, prior = "noninformative", theta = 0.3)
+
+  expect_no_error(plot(model, n_grid = 8, engine = "ggplot"))
+  expect_error(plot(model, engine = "bad_engine"), "`engine` must be one of c('base', 'ggplot').", fixed = TRUE)
+})

--- a/tests/testthat/test-plot_DKP.R
+++ b/tests/testthat/test-plot_DKP.R
@@ -115,3 +115,18 @@ test_that("plot.DKP validates input arguments and classification branches", {
   expect_error(plot(model, dims = c(1, 1)), "`dims` cannot contain duplicate indices")
   expect_error(plot(model, dims = 3), "must be within the range")
 })
+
+
+test_that("plot.DKP supports ggplot engine for 2D and validates engine", {
+  set.seed(2026)
+  skip_if_not_installed("ggplot2")
+
+  X <- matrix(runif(80), ncol = 2)
+  cl <- sample(1:3, nrow(X), replace = TRUE)
+  Y <- matrix(0, nrow(X), 3)
+  Y[cbind(seq_len(nrow(X)), cl)] <- 1
+  model <- fit_DKP(X, Y, prior = "noninformative", theta = 0.25)
+
+  expect_no_error(plot(model, n_grid = 8, engine = "ggplot"))
+  expect_error(plot(model, engine = "bad_engine"), "`engine` must be one of c('base', 'ggplot').", fixed = TRUE)
+})


### PR DESCRIPTION
### Motivation
- Provide users a choice of 2D plotting backend so the plotting code can produce `ggplot2`-style figures in addition to the existing lattice/base output while preserving current defaults. 
- Make it straightforward to switch backends for 2D visualizations (classification and regression surfaces) without changing existing function signatures for 1D behavior.

### Description
- Added an `engine` argument (default `"base"`) with validation to `plot.BKP()` and `plot.DKP()` and updated the docblocks and `man/plot.Rd` accordingly; invalid values error with a clear message. (`R/plot_BKP.R`, `R/plot_DKP.R`).
- Implemented ggplot-based 2D helper functions `my_2D_plot_fun_ggplot()` and `my_2D_plot_fun_class_ggplot()` for continuous surfaces and class maps and added them to `R/utils.R`.
- Updated 2D plotting branches to dispatch between the original lattice/base plotting helpers and the new ggplot helpers depending on `engine`, and used `gridExtra::grid.arrange` consistently when arranging panels.
- Added `ggplot2` to `Imports` in `DESCRIPTION` and updated tests to cover `engine = "ggplot"` success path and invalid-engine error handling by extending `tests/testthat/test-plot_BKP.R` and `tests/testthat/test-plot_DKP.R`.

### Testing
- Updated/added unit tests: `tests/testthat/test-plot_BKP.R` and `tests/testthat/test-plot_DKP.R` now include cases exercising `engine = "ggplot"` and validation for bad `engine` values.
- Attempted to run the plot tests with `R -q -e "testthat::test_file('tests/testthat/test-plot_BKP.R')"`, but test execution failed because the environment does not have `R` installed (`bash: command not found: R`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4022f80f48320ab5dd260d2ca0a10)