### PR TITLE
ci: upgrade pak on R-devel before setup-r-dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,16 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Upgrade pak (R devel compatibility)
+        if: matrix.config.r == 'devel'
+        shell: Rscript {0}
+        run: |
+          options(repos = c(CRAN = "https://cloud.r-project.org"))
+          if (!requireNamespace("remotes", quietly = TRUE)) {
+            install.packages("remotes")
+          }
+          remotes::install_github("r-lib/pak", upgrade = "never", dependencies = FALSE)
+
       # Cache TinyTeX (to make subsequent builds faster)
       - name: Cache TinyTeX
         uses: actions/cache@v4


### PR DESCRIPTION
### Motivation
- CI runs on macOS were failing during dependency installation when `pak::lockfile_install()` tried to build `fs` from source, ending with `Error in if (custom.bin) { : argument is of length zero`, which is consistent with pak/R-devel compatibility regressions. 
- The change aims to avoid that class of failures by ensuring a newer `pak` is used on R-devel runner jobs before dependency installation.

### Description
- Add a new step to ` .github/workflows/R-CMD-check.yaml` that runs only when `matrix.config.r == 'devel'` and installs `r-lib/pak` from GitHub via `remotes::install_github("r-lib/pak", upgrade = "never", dependencies = FALSE)` executed under `Rscript`. 
- The step is placed immediately after `r-lib/actions/setup-r@v2` and before `r-lib/actions/setup-r-dependencies@v2` so the upgraded `pak` is available for lockfile installs. 
- The change is scoped to R-devel jobs only to minimize impact on `release` and `oldrel-1` builds.

### Testing
- Inspected the workflow diff and file contents to confirm the new step appears at the correct location in ` .github/workflows/R-CMD-check.yaml` and shows the added lines (checked via file preview). 
- Attempted to parse the workflow with `python` using `yaml.safe_load`, which failed due to the environment missing `PyYAML` and not due to the workflow content. 
- Verified the working tree reflects the update and displayed the inserted lines to confirm the patch was applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4bf79d99883208526af7a8d0645ed)