### PR TITLE
ci: force source package installs on Windows to avoid pak lockfile failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,9 +22,9 @@ jobs:
           - {os: macos-latest,   r: 'release'}
           - {os: macos-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: macos-latest,   r: 'oldrel-1'}
-          - {os: windows-latest,   r: 'release', pak-pkg-type: 'source'}
+          - {os: windows-latest,   r: 'release'}
           - {os: windows-latest,   r: 'devel', http-user-agent: 'release', pak-pkg-type: 'source'}
-          - {os: windows-latest,   r: 'oldrel-1', pak-pkg-type: 'source'}
+          - {os: windows-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,9 +22,9 @@ jobs:
           - {os: macos-latest,   r: 'release'}
           - {os: macos-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: macos-latest,   r: 'oldrel-1'}
-          - {os: windows-latest,   r: 'release'}
-          - {os: windows-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: windows-latest,   r: 'oldrel-1'}
+          - {os: windows-latest,   r: 'release', pak-pkg-type: 'source'}
+          - {os: windows-latest,   r: 'devel', http-user-agent: 'release', pak-pkg-type: 'source'}
+          - {os: windows-latest,   r: 'oldrel-1', pak-pkg-type: 'source'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
@@ -32,6 +32,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PAK_PKG_TYPE: ${{ matrix.config.pak-pkg-type || 'binary' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- CI runs were failing on Windows during `pak::lockfile_install()` due to intermittent binary archive/download issues (e.g. `fs` download failure) that produced `cannot open the connection` errors, while macOS/Ubuntu passed.

### Description
- Updated `.github/workflows/R-CMD-check.yaml` to mark all Windows matrix rows with `pak-pkg-type: 'source'` and added `PAK_PKG_TYPE` to the job `env` (defaulting non-Windows jobs to `binary`) so Windows runs use source installs to avoid unreliable binary downloads.

### Testing
- No automated package tests were executed locally because this is a workflow-only change; the change will be validated by CI on the next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4daa2353483209aa53c9e1dbf8564)