### PR TITLE
ci: fix Windows devel dependency setup by upgrading pak

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,8 +45,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Upgrade pak (R devel compatibility on macOS only)
-        if: matrix.config.r == 'devel' && startsWith(matrix.config.os, 'macos')
+      - name: Upgrade pak (R devel compatibility)
+        if: matrix.config.r == 'devel'
         shell: Rscript {0}
         run: |
           options(repos = c(CRAN = "https://cloud.r-project.org"))


### PR DESCRIPTION
### Motivation
- Ensure the CI `r: devel` matrix jobs (including Windows) upgrade `pak` before `setup-r-dependencies` to avoid pak-related download/lockfile failures (e.g. `fs` download hiccups leading to `file(con, "rb") cannot open the connection`).

### Description
- Updated `.github/workflows/R-CMD-check.yaml` to change the `Upgrade pak` step `if` from `matrix.config.r == 'devel' && startsWith(matrix.config.os, 'macos')` to `matrix.config.r == 'devel'` so the upgrade runs for all devel jobs. 

### Testing
- Reviewed the workflow diff and ran `git diff -- .github/workflows/R-CMD-check.yaml && git diff --check` and committed the change, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e055803c8320b8af5ffca9597ada)