### PR TITLE
ci: refresh R dependency cache for R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -84,6 +84,9 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
+          # Bump dependency cache to recover from intermittently corrupted archives
+          # in the Windows devel package cache (e.g. fs binary download failures).
+          cache-version: 2
 
       - uses: r-lib/actions/check-r-package@v2
         with:


### PR DESCRIPTION
### Motivation
- Force a rebuild of the R dependency cache to avoid intermittent Windows `devel` failures during `pak::lockfile_install(".github/pkg.lock")` caused by corrupted cached package archives (for example an `fs` binary download failure that led to `cannot open the connection`).

### Description
- Add `cache-version: 2` to the `r-lib/actions/setup-r-dependencies@v2` step in `.github/workflows/R-CMD-check.yaml` and include comments explaining the change to invalidate the old cache and recover from corrupted Windows package artifacts.

### Testing
- No automated CI runs were triggered by this change; the workflow file diff and syntax were reviewed locally and are valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e32d11f08320b166bd81120432f2)