### PR TITLE
Refactor test helpers and capture print output

### DIFF
--- a/tests/testthat/helper-BKP.R
+++ b/tests/testthat/helper-BKP.R
@@ -1,0 +1,53 @@
+make_bkp_model_1d <- function() {
+  set.seed(123)
+
+  true_pi_fun <- function(x) {
+    (1 + exp(-x^2) * cos(10 * (1 - exp(-x)) / (1 + exp(-x)))) / 2
+  }
+
+  n <- 30
+  Xbounds <- matrix(c(-2, 2), nrow = 1)
+  X <- matrix(runif(n, Xbounds[1], Xbounds[2]), ncol = 1)
+  true_pi <- true_pi_fun(X)
+  m <- sample(100, n, replace = TRUE)
+  y <- rbinom(n, size = m, prob = true_pi)
+
+  model <- fit_BKP(
+    X, y, m,
+    Xbounds = Xbounds,
+    prior = "noninformative"
+  )
+
+  list(
+    X = X,
+    y = y,
+    m = m,
+    Xbounds = Xbounds,
+    model = model
+  )
+}
+
+
+make_bkp_model_3d_classification <- function() {
+  set.seed(100)
+
+  X <- matrix(runif(36), ncol = 3)
+  m <- rep(1, nrow(X))
+  y <- rbinom(nrow(X), size = 1, prob = 0.5)
+
+  model <- fit_BKP(
+    X, y, m,
+    prior = "fixed",
+    r0 = 5,
+    p0 = 0.5,
+    theta = c(0.3, 0.4, 0.5),
+    isotropic = FALSE
+  )
+
+  list(
+    X = X,
+    y = y,
+    m = m,
+    model = model
+  )
+}

--- a/tests/testthat/helper-DKP.R
+++ b/tests/testthat/helper-DKP.R
@@ -1,0 +1,59 @@
+make_dkp_model_1d <- function() {
+  set.seed(123)
+
+  true_pi_fun <- function(X) {
+    p1 <- 1 / (1 + exp(-3 * X))
+    p2 <- (1 + exp(-X^2) * cos(10 * (1 - exp(-X)) / (1 + exp(-X)))) / 2
+    matrix(c(p1 / 2, p2 / 2, 1 - (p1 + p2) / 2), nrow = length(p1))
+  }
+
+  n <- 30
+  Xbounds <- matrix(c(-2, 2), nrow = 1)
+  X <- matrix(runif(n, Xbounds[1], Xbounds[2]), ncol = 1)
+  true_pi <- true_pi_fun(X)
+  m <- sample(150, n, replace = TRUE)
+
+  Y <- t(sapply(seq_len(n), function(i) {
+    rmultinom(1, size = m[i], prob = true_pi[i, ])
+  }))
+
+  model <- fit_DKP(
+    X, Y,
+    Xbounds = Xbounds,
+    prior = "noninformative"
+  )
+
+  list(
+    X = X,
+    Y = Y,
+    m = m,
+    Xbounds = Xbounds,
+    model = model
+  )
+}
+
+
+make_dkp_model_3d_classification <- function() {
+  set.seed(100)
+
+  X <- matrix(runif(45), ncol = 3)
+  Y <- matrix(0, nrow(X), 4)
+
+  cls <- sample(1:4, nrow(X), replace = TRUE)
+  Y[cbind(seq_len(nrow(X)), cls)] <- 1
+
+  model <- fit_DKP(
+    X, Y,
+    prior = "fixed",
+    r0 = 6,
+    p0 = rep(0.25, 4),
+    theta = c(0.35, 0.4, 0.45),
+    isotropic = FALSE
+  )
+
+  list(
+    X = X,
+    Y = Y,
+    model = model
+  )
+}

--- a/tests/testthat/test-print_BKP.R
+++ b/tests/testthat/test-print_BKP.R
@@ -3,36 +3,8 @@
 # It captures console output so that print methods do not pollute test output.
 
 test_that("print.BKP methods run without errors and produce expected output", {
-  set.seed(123)
-
-  # -------------------------------------------------------------------------
-  # Setup: Create a BKP model and related objects
-  # -------------------------------------------------------------------------
-
-  true_pi_fun <- function(x) {
-    (1 + exp(-x^2) * cos(10 * (1 - exp(-x)) / (1 + exp(-x)))) / 2
-  }
-
-  n <- 30
-  Xbounds <- matrix(c(-2, 2), nrow = 1)
-  X <- matrix(runif(n, Xbounds[1], Xbounds[2]), ncol = 1)
-  true_pi <- true_pi_fun(X)
-  m <- sample(100, n, replace = TRUE)
-  y <- rbinom(n, size = m, prob = true_pi)
-
-  model <- fit_BKP(
-    X, y, m,
-    Xbounds = Xbounds,
-    prior = "noninformative"
-  )
-
-  summary_model <- summary(model)
-  predict_model <- predict(model)
-  simulate_model <- simulate(model)
-
-  # -------------------------------------------------------------------------
-  # Test Cases: Verify print methods while capturing console output
-  # -------------------------------------------------------------------------
+  fit <- make_bkp_model_1d()
+  model <- fit$model
 
   expect_output(
     print(model),
@@ -40,39 +12,26 @@ test_that("print.BKP methods run without errors and produce expected output", {
   )
 
   expect_output(
-    print(summary_model),
+    print(summary(model)),
     "Beta Kernel Process"
   )
 
   expect_output(
-    print(predict_model),
+    print(predict(model)),
     "Prediction results"
   )
 
   expect_output(
-    print(simulate_model),
+    print(simulate(model)),
     "Simulation results"
   )
 })
 
 
 test_that("print.BKP handles new-data and high-dimensional branches", {
-  set.seed(100)
-
-  X <- matrix(runif(36), ncol = 3)
-  m <- rep(1, nrow(X))
-  y <- rbinom(nrow(X), size = 1, prob = 0.5)
-
-  model <- fit_BKP(
-    X, y, m,
-    prior = "fixed",
-    r0 = 5,
-    p0 = 0.5,
-    theta = c(0.3, 0.4, 0.5),
-    isotropic = FALSE
-  )
-
-  Xnew <- X[1:5, , drop = FALSE]
+  fit <- make_bkp_model_3d_classification()
+  model <- fit$model
+  Xnew <- fit$X[1:5, , drop = FALSE]
 
   expect_output(
     print(model),

--- a/tests/testthat/test-print_DKP.R
+++ b/tests/testthat/test-print_DKP.R
@@ -3,41 +3,8 @@
 # It captures console output so that print methods do not pollute test output.
 
 test_that("print.DKP methods run without errors and produce expected output", {
-  set.seed(123)
-
-  # -------------------------------------------------------------------------
-  # Setup: Create a DKP model and related objects
-  # -------------------------------------------------------------------------
-
-  true_pi_fun <- function(X) {
-    p1 <- 1 / (1 + exp(-3 * X))
-    p2 <- (1 + exp(-X^2) * cos(10 * (1 - exp(-X)) / (1 + exp(-X)))) / 2
-    matrix(c(p1 / 2, p2 / 2, 1 - (p1 + p2) / 2), nrow = length(p1))
-  }
-
-  n <- 30
-  Xbounds <- matrix(c(-2, 2), nrow = 1)
-  X <- matrix(runif(n, Xbounds[1], Xbounds[2]), ncol = 1)
-  true_pi <- true_pi_fun(X)
-  m <- sample(150, n, replace = TRUE)
-
-  Y <- t(sapply(seq_len(n), function(i) {
-    rmultinom(1, size = m[i], prob = true_pi[i, ])
-  }))
-
-  model <- fit_DKP(
-    X, Y,
-    Xbounds = Xbounds,
-    prior = "noninformative"
-  )
-
-  summary_model <- summary(model)
-  predict_model <- predict(model)
-  simulate_model <- simulate(model)
-
-  # -------------------------------------------------------------------------
-  # Test Cases: Verify print methods while capturing console output
-  # -------------------------------------------------------------------------
+  fit <- make_dkp_model_1d()
+  model <- fit$model
 
   expect_output(
     print(model),
@@ -45,41 +12,26 @@ test_that("print.DKP methods run without errors and produce expected output", {
   )
 
   expect_output(
-    print(summary_model),
+    print(summary(model)),
     "Dirichlet Kernel Process"
   )
 
   expect_output(
-    print(predict_model),
+    print(predict(model)),
     "Prediction results"
   )
 
   expect_output(
-    print(simulate_model),
+    print(simulate(model)),
     "Simulation results"
   )
 })
 
 
 test_that("print.DKP handles new-data, multi-class and high-dimensional branches", {
-  set.seed(100)
-
-  X <- matrix(runif(45), ncol = 3)
-  Y <- matrix(0, nrow(X), 4)
-
-  cls <- sample(1:4, nrow(X), replace = TRUE)
-  Y[cbind(seq_len(nrow(X)), cls)] <- 1
-
-  model <- fit_DKP(
-    X, Y,
-    prior = "fixed",
-    r0 = 6,
-    p0 = rep(0.25, 4),
-    theta = c(0.35, 0.4, 0.45),
-    isotropic = FALSE
-  )
-
-  Xnew <- X[1:5, , drop = FALSE]
+  fit <- make_dkp_model_3d_classification()
+  model <- fit$model
+  Xnew <- fit$X[1:5, , drop = FALSE]
 
   expect_output(
     print(model),

--- a/tests/testthat/test-print_TwinBKP.R
+++ b/tests/testthat/test-print_TwinBKP.R
@@ -11,6 +11,11 @@ test_that("TwinBKP print methods produce expected output", {
   )
 
   expect_output(
+    print(summary(model)),
+    "Twin Beta Kernel Process"
+  )
+
+  expect_output(
     print(predict(model)),
     "TwinBKP prediction"
   )


### PR DESCRIPTION
### Motivation

- Unify BKP/DKP/TwinBKP test fixtures so print tests reuse small model constructors instead of duplicating model setup code.
- Prevent print methods from polluting test output by capturing and asserting printed content instead of allowing raw console output.
- Prefer `expect_output(print(...), "...")` to both capture and validate print output while retaining the expectation that print produces output.

### Description

- Add shared BKP test helpers in `tests/testthat/helper-BKP.R` that provide `make_bkp_model_1d()` and `make_bkp_model_3d_classification()`.
- Add shared DKP test helpers in `tests/testthat/helper-DKP.R` that provide `make_dkp_model_1d()` and `make_dkp_model_3d_classification()`.
- Rewrite `tests/testthat/test-print_BKP.R` and `tests/testthat/test-print_DKP.R` to use the new helpers and replace prior ad-hoc model construction with calls to the helpers.
- Update `tests/testthat/test-print_BKP.R`, `tests/testthat/test-print_DKP.R`, and `tests/testthat/test-print_TwinBKP.R` to use `expect_output(print(...), "<expected title>")` for `model`, `summary`, `predict`, and `simulate` outputs, and remove prior uses of `expect_silent(print(...))`/`expect_no_error(print(...))` in those print tests.

### Testing

- Ran a repository-wide search to ensure there are no remaining `expect_no_error(print(...))` or `expect_silent(print(...))`, and the print tests now use `expect_output()` as intended.
- Attempted to run `devtools::test(filter = "print")`, `devtools::test(filter = "TwinBKP")`, and `devtools::check()`, but the environment lacks `R` so those commands could not be executed (`R: command not found`).
- Performed local diffs and file inspections to verify the new helper files exist and the three print test files were updated to call the helpers and assert printed content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3be07db8c48320b32ebf39ed0709d0)