### PR TITLE
Clean TwinDKP R style and remove prediction `class` field

### DIFF
--- a/R/fit_TwinDKP.R
+++ b/R/fit_TwinDKP.R
@@ -41,79 +41,327 @@ fit_TwinDKP <- function(
     store_kernel = FALSE,
     control = list()
 ) {
-  if (missing(X) || missing(Y)) stop("Arguments 'X' and 'Y' must be provided.")
-  if (!is.matrix(X) && !is.data.frame(X)) stop("'X' must be a numeric matrix or data frame.")
-  if (!is.numeric(as.matrix(X))) stop("'X' must contain numeric values only.")
-  if (!is.matrix(Y) && !is.data.frame(Y)) stop("'Y' must be a numeric matrix or data frame.")
-  if (!is.numeric(as.matrix(Y))) stop("'Y' must contain numeric values only.")
-  X <- as.matrix(X); Y <- as.matrix(Y)
-  d <- ncol(X); n <- nrow(X); q <- ncol(Y)
-  if (n < 3L) stop("TwinDKP requires at least three observations.")
-  if (nrow(Y) != n) stop("Number of rows in 'Y' must match number of rows in 'X'.")
-  if (q < 2L) stop("'Y' must have at least two columns (multinomial outcomes).")
-  if (any(Y < 0)) stop("'Y' must be nonnegative counts or frequencies.")
-  if (any(rowSums(Y) <= 0)) stop("Each row of 'Y' must have a positive row sum.")
-  if (anyNA(X) || anyNA(Y)) stop("Missing values are not allowed in 'X' or 'Y'.")
-  if (any(!is.finite(X)) || any(!is.finite(Y))) stop("'X' and 'Y' must contain only finite values.")
-  if ("ess" %in% names(control)) stop("TwinDKP does not support ESS calibration; use fit_DKP(ess = ...) for full DKP ESS support.")
-  prior <- match.arg(prior); global_kernel <- match.arg(global_kernel); local_kernel <- match.arg(local_kernel); loss <- match.arg(loss)
-  if (is.null(p0)) p0 <- colMeans(sweep(Y, 1, rowSums(Y), "/"))
+  # ---- Argument checking ----
+  if (missing(X) || missing(Y)) {
+    stop("Arguments 'X' and 'Y' must be provided.")
+  }
+  if (!is.matrix(X) && !is.data.frame(X)) {
+    stop("'X' must be a numeric matrix or data frame.")
+  }
+  if (!is.numeric(as.matrix(X))) {
+    stop("'X' must contain numeric values only.")
+  }
+  if (!is.matrix(Y) && !is.data.frame(Y)) {
+    stop("'Y' must be a numeric matrix or data frame.")
+  }
+  if (!is.numeric(as.matrix(Y))) {
+    stop("'Y' must contain numeric values only.")
+  }
+
+  X <- as.matrix(X)
+  Y <- as.matrix(Y)
+
+  d <- ncol(X)
+  n <- nrow(X)
+  q <- ncol(Y)
+
+  if (n < 3L) {
+    stop("TwinDKP requires at least three observations.")
+  }
+  if (nrow(Y) != n) {
+    stop("Number of rows in 'Y' must match number of rows in 'X'.")
+  }
+  if (q < 2L) {
+    stop("'Y' must have at least two columns (multinomial outcomes).")
+  }
+  if (any(Y < 0)) {
+    stop("'Y' must be nonnegative counts or frequencies.")
+  }
+  if (any(rowSums(Y) <= 0)) {
+    stop("Each row of 'Y' must have a positive row sum.")
+  }
+  if (anyNA(X) || anyNA(Y)) {
+    stop("Missing values are not allowed in 'X' or 'Y'.")
+  }
+  if (any(!is.finite(X)) || any(!is.finite(Y))) {
+    stop("'X' and 'Y' must contain only finite values.")
+  }
+  if ("ess" %in% names(control)) {
+    stop("TwinDKP does not support ESS calibration; use fit_DKP(ess = ...) for full DKP ESS support.")
+  }
+
+  # ---- Prior, kernels, and loss ----
+  prior <- match.arg(prior)
+  global_kernel <- match.arg(global_kernel)
+  local_kernel <- match.arg(local_kernel)
+  loss <- match.arg(loss)
+
+  if (is.null(p0)) {
+    p0 <- colMeans(sweep(Y, 1, rowSums(Y), "/"))
+  }
+
+  if (!is.numeric(r0) || length(r0) != 1 || r0 <= 0 || is.na(r0) || !is.finite(r0)) {
+    stop("'r0' must be a positive scalar.")
+  }
+  if (prior == "fixed" &&
+      (is.null(p0) || !is.numeric(p0) || length(p0) != q || anyNA(p0) ||
+       any(!is.finite(p0)) || any(p0 < 0) || abs(sum(p0) - 1) > 1e-10)) {
+    stop("For fixed prior in DKP, 'p0' must be a nonnegative finite numeric vector of length equal to the number of classes and sum to 1.")
+  }
+  if (!is.logical(isotropic) || length(isotropic) != 1) {
+    stop("'isotropic' must be a single logical value.")
+  }
+
+  n_multi_start <- control$n_multi_start
+  n_threads <- if (is.null(control$n_threads)) 1 else control$n_threads
+
+  if (!is.null(n_multi_start) &&
+      (!is.numeric(n_multi_start) || length(n_multi_start) != 1 ||
+       is.na(n_multi_start) || !is.finite(n_multi_start) ||
+       n_multi_start <= 0 || n_multi_start != floor(n_multi_start))) {
+    stop("'n_multi_start' must be a positive integer.")
+  }
+  if (!is.numeric(n_threads) || length(n_threads) != 1 ||
+      is.na(n_threads) || !is.finite(n_threads) || n_threads <= 0) {
+    stop("'n_threads' must be a positive integer.")
+  }
+  if (!is.null(theta_g)) {
+    if (!is.numeric(theta_g)) {
+      stop("'theta_g' must be numeric.")
+    }
+    if (isTRUE(isotropic) && length(theta_g) != 1) {
+      stop("When isotropic=TRUE, 'theta_g' must be a scalar.")
+    }
+    if (!isTRUE(isotropic) && !(length(theta_g) == 1 || length(theta_g) == d)) {
+      stop(paste0("When isotropic=FALSE, 'theta_g' must be either a scalar or a vector of length ", d, "."))
+    }
+    if (!isTRUE(isotropic) && length(theta_g) == 1) {
+      theta_g <- rep(theta_g, d)
+    }
+    if (anyNA(theta_g) || any(!is.finite(theta_g)) || any(theta_g <= 0)) {
+      stop("'theta_g' must be strictly positive.")
+    }
+  }
+  if (!is.null(theta_l) &&
+      (!is.numeric(theta_l) || length(theta_l) != 1 || is.na(theta_l) ||
+       !is.finite(theta_l) || theta_l <= 0)) {
+    stop("'theta_l' must be a positive scalar.")
+  }
+  if (!is.numeric(twins) || length(twins) != 1 || is.na(twins) ||
+      !is.finite(twins) || twins <= 0 || twins != floor(twins)) {
+    stop("'twins' must be a positive integer.")
+  }
+  if (!is.logical(store_kernel) || length(store_kernel) != 1) {
+    stop("'store_kernel' must be a single logical value.")
+  }
+
+  # ---- Normalize input X to [0,1]^d ----
   if (is.null(Xbounds)) {
-    xmin <- min(X); xmax <- max(X)
-    if (xmin < 0 || xmax > 1) warning(sprintf("Input X does not appear to be normalized to [0,1]. Current range: [%.3f, %.3f].\nPlease normalize X or specify Xbounds explicitly; otherwise the model may produce incorrect results.", xmin, xmax))
+    xmin <- min(X)
+    xmax <- max(X)
+    if (xmin < 0 || xmax > 1) {
+      warning(sprintf(
+        "Input X does not appear to be normalized to [0,1]. Current range: [%.3f, %.3f].\nPlease normalize X or specify Xbounds explicitly; otherwise the model may produce incorrect results.",
+        xmin, xmax
+      ))
+    }
     Xbounds <- cbind(rep(0, d), rep(1, d))
   } else {
-    if (!is.matrix(Xbounds)) stop("'Xbounds' must be a numeric matrix.")
-    if (!is.numeric(Xbounds)) stop("'Xbounds' must contain numeric values.")
-    if (!all(dim(Xbounds) == c(d, 2))) stop(paste0("'Xbounds' must be a matrix with dimensions d x 2, where d = ", d, "."))
-    if (anyNA(Xbounds) || any(!is.finite(Xbounds))) stop("'Xbounds' must contain only finite values.")
-    if (any(Xbounds[,2] <= Xbounds[,1])) stop("Each row of 'Xbounds' must satisfy lower < upper.")
+    if (!is.matrix(Xbounds)) {
+      stop("'Xbounds' must be a numeric matrix.")
+    }
+    if (!is.numeric(Xbounds)) {
+      stop("'Xbounds' must contain numeric values.")
+    }
+    if (!all(dim(Xbounds) == c(d, 2))) {
+      stop(paste0("'Xbounds' must be a matrix with dimensions d x 2, where d = ", d, "."))
+    }
+    if (anyNA(Xbounds) || any(!is.finite(Xbounds))) {
+      stop("'Xbounds' must contain only finite values.")
+    }
+    if (any(Xbounds[, 2] <= Xbounds[, 1])) {
+      stop("Each row of 'Xbounds' must satisfy lower < upper.")
+    }
   }
-  if (!is.numeric(r0) || length(r0) != 1 || r0 <= 0 || is.na(r0) || !is.finite(r0)) stop("'r0' must be a positive scalar.")
-  if (prior == "fixed" && (is.null(p0) || !is.numeric(p0) || length(p0) != q || anyNA(p0) || any(!is.finite(p0)) || any(p0 < 0) || abs(sum(p0) - 1) > 1e-10)) stop("For fixed prior in DKP, 'p0' must be a nonnegative finite numeric vector of length equal to the number of classes and sum to 1.")
-  if (!is.logical(isotropic) || length(isotropic) != 1) stop("'isotropic' must be a single logical value.")
-  n_multi_start <- control$n_multi_start; n_threads <- if (is.null(control$n_threads)) 1 else control$n_threads
-  if (!is.null(n_multi_start) && (!is.numeric(n_multi_start) || length(n_multi_start) != 1 || is.na(n_multi_start) || !is.finite(n_multi_start) || n_multi_start <= 0 || n_multi_start != floor(n_multi_start))) stop("'n_multi_start' must be a positive integer.")
-  if (!is.numeric(n_threads) || length(n_threads) != 1 || is.na(n_threads) || !is.finite(n_threads) || n_threads <= 0) stop("'n_threads' must be a positive integer.")
-  if (!is.null(theta_g)) {
-    if (!is.numeric(theta_g)) stop("'theta_g' must be numeric.")
-    if (isTRUE(isotropic) && length(theta_g) != 1) stop("When isotropic=TRUE, 'theta_g' must be a scalar.")
-    if (!isTRUE(isotropic) && !(length(theta_g) == 1 || length(theta_g) == d)) stop(paste0("When isotropic=FALSE, 'theta_g' must be either a scalar or a vector of length ", d, "."))
-    if (!isTRUE(isotropic) && length(theta_g) == 1) theta_g <- rep(theta_g, d)
-    if (anyNA(theta_g) || any(!is.finite(theta_g)) || any(theta_g <= 0)) stop("'theta_g' must be strictly positive.")
-  }
-  if (!is.null(theta_l) && (!is.numeric(theta_l) || length(theta_l) != 1 || is.na(theta_l) || !is.finite(theta_l) || theta_l <= 0)) stop("'theta_l' must be a positive scalar.")
-  if (!is.numeric(twins) || length(twins) != 1 || is.na(twins) || !is.finite(twins) || twins <= 0 || twins != floor(twins)) stop("'twins' must be a positive integer.")
-  if (!is.logical(store_kernel) || length(store_kernel) != 1) stop("'store_kernel' must be a single logical value.")
-  Xnorm <- sweep(sweep(X, 2, Xbounds[,1], "-"), 2, Xbounds[,2] - Xbounds[,1], "/")
-  if (is.null(g)) g <- as.integer(max(2L, min(n - 1L, 50L * d, max(floor(sqrt(n)), 10L * d)))) else {
-    if (!is.numeric(g) || length(g) != 1 || g != floor(g) || is.na(g) || !is.finite(g) || g < 2 || g >= n) stop("'g' must be an integer between 2 and n - 1.")
+
+  Xnorm <- sweep(X, 2, Xbounds[, 1], "-")
+  Xnorm <- sweep(Xnorm, 2, Xbounds[, 2] - Xbounds[, 1], "/")
+
+  # ---- Twinning global subset selection ----
+  if (is.null(g)) {
+    g <- as.integer(max(2L, min(n - 1L, 50L * d, max(floor(sqrt(n)), 10L * d))))
+  } else {
+    if (!is.numeric(g) || length(g) != 1 || g != floor(g) ||
+        is.na(g) || !is.finite(g) || g < 2 || g >= n) {
+      stop("'g' must be an integer between 2 and n - 1.")
+    }
     g <- as.integer(g)
   }
-  r <- as.integer(max(2L, ceiling(n / g))); twins <- as.integer(twins); leaf_size <- 8L
-  P_hat <- sweep(Y, 1, rowSums(Y), "/"); twin_data <- cbind(Xnorm, P_hat); storage.mode(twin_data) <- "double"
-  center <- colMeans(twin_data); first <- which.max(rowSums(sweep(twin_data, 2, center, "-")^2))
-  u1 <- if (twins <= 1L) as.integer(first) else as.integer(c(first, sample(setdiff(seq_len(n), first), twins - 1L, replace = (twins - 1L) > (n - 1L))))
-  twin_info <- twin_select_global_rcpp(twin_data = twin_data, Xnorm = Xnorm, r = r, runs = twins, u1 = u1, leaf_size = leaf_size)
-  g_indices <- as.integer(twin_info$g_indices); g_actual <- length(g_indices)
-  if (g_actual < 2L) stop("The Twinning step selected fewer than two global points; try increasing 'g'.")
-  if (is.null(theta_l)) theta_l <- as.numeric(twin_info$theta_l)
+
+  r <- as.integer(max(2L, ceiling(n / g)))
+  twins <- as.integer(twins)
+  leaf_size <- 8L
+  P_hat <- sweep(Y, 1, rowSums(Y), "/")
+  twin_data <- cbind(Xnorm, P_hat)
+  storage.mode(twin_data) <- "double"
+  center <- colMeans(twin_data)
+  first <- which.max(rowSums(sweep(twin_data, 2, center, "-")^2))
+  u1 <- if (twins <= 1L) {
+    as.integer(first)
+  } else {
+    as.integer(c(
+      first,
+      sample(
+        setdiff(seq_len(n), first),
+        twins - 1L,
+        replace = (twins - 1L) > (n - 1L)
+      )
+    ))
+  }
+
+  twin_info <- twin_select_global_rcpp(
+    twin_data = twin_data,
+    Xnorm = Xnorm,
+    r = r,
+    runs = twins,
+    u1 = u1,
+    leaf_size = leaf_size
+  )
+  g_indices <- as.integer(twin_info$g_indices)
+  g_actual <- length(g_indices)
+
+  if (g_actual < 2L) {
+    stop("The Twinning step selected fewer than two global points; try increasing 'g'.")
+  }
+  if (is.null(theta_l)) {
+    theta_l <- as.numeric(twin_info$theta_l)
+  }
+
   non_global_n <- n - g_actual
-  if (is.null(l)) l <- min(non_global_n, max(25L, 3L * d)) else { if (!is.numeric(l) || length(l) != 1 || l != floor(l) || is.na(l) || !is.finite(l) || l < 0) stop("'l' must be a nonnegative integer."); l <- as.integer(l); if (l > non_global_n) stop("'l' cannot exceed the number of non-global training points.") }
+  if (is.null(l)) {
+    l <- min(non_global_n, max(25L, 3L * d))
+  } else {
+    if (!is.numeric(l) || length(l) != 1 || l != floor(l) ||
+        is.na(l) || !is.finite(l) || l < 0) {
+      stop("'l' must be a nonnegative integer.")
+    }
+    l <- as.integer(l)
+    if (l > non_global_n) {
+      stop("'l' cannot exceed the number of non-global training points.")
+    }
+  }
+
+  # ---- Global lengthscale tuning ----
   if (is.null(theta_g)) {
-    global_fit <- fit_DKP(X[g_indices,,drop=FALSE], Y[g_indices,,drop=FALSE], Xbounds = Xbounds, prior = prior, r0 = r0, p0 = p0, kernel = global_kernel, loss = loss, n_multi_start = n_multi_start, theta = NULL, isotropic = isotropic, n_threads = as.integer(n_threads), ess = "none")
-    theta_g <- as.numeric(global_fit$theta_opt); loss_min <- as.numeric(global_fit$loss_min)
+    global_fit <- fit_DKP(
+      X[g_indices, , drop = FALSE],
+      Y[g_indices, , drop = FALSE],
+      Xbounds = Xbounds,
+      prior = prior,
+      r0 = r0,
+      p0 = p0,
+      kernel = global_kernel,
+      loss = loss,
+      n_multi_start = n_multi_start,
+      theta = NULL,
+      isotropic = isotropic,
+      n_threads = as.integer(n_threads),
+      ess = "none"
+    )
+    theta_g <- as.numeric(global_fit$theta_opt)
+    loss_min <- as.numeric(global_fit$loss_min)
   } else {
     theta_g <- as.numeric(theta_g)
-    loss_min <- loss_fun(gamma = log10(theta_g), Xnorm = Xnorm[g_indices,,drop=FALSE], Y = Y[g_indices,,drop=FALSE], prior = prior, r0 = r0, p0 = p0, model = "DKP", loss = loss, kernel = global_kernel, isotropic = isotropic, ess = "none")
+    loss_min <- loss_fun(
+      gamma = log10(theta_g),
+      Xnorm = Xnorm[g_indices, , drop = FALSE],
+      Y = Y[g_indices, , drop = FALSE],
+      prior = prior,
+      r0 = r0,
+      p0 = p0,
+      model = "DKP",
+      loss = loss,
+      kernel = global_kernel,
+      isotropic = isotropic,
+      ess = "none"
+    )
   }
-  local_indices <- twin_local_indices_rcpp(Xtrain_norm = Xnorm, Xquery_norm = Xnorm, g_indices = g_indices, l = l, leaf_size = leaf_size)
-  posterior <- .twindkp_compute_posterior(Xnorm, Xnorm, Y, g_indices, local_indices, theta_g, theta_l, global_kernel, local_kernel, isotropic, prior, r0, p0, store_kernel)
-  out <- list(theta_opt = theta_g, theta_g = theta_g, theta_l = theta_l, kernel = global_kernel, global_kernel = global_kernel, local_kernel = local_kernel, isotropic = isotropic, loss = loss, loss_min = loss_min, X = X, Xnorm = Xnorm, Xbounds = Xbounds, Y = Y, prior = prior, r0 = r0, p0 = p0, alpha0 = posterior$alpha0, alpha_n = posterior$alpha_n, prob = posterior$prob, global_indices = g_indices, control = list(g_target = g, g = g_actual, l = l, r = r, twins = twins, u1 = u1, leaf_size = leaf_size, store_kernel = store_kernel), diagnostics = list(twin_info = twin_info, K = posterior$K, K_global = posterior$K_global, K_local = posterior$K_local), ess = "none", ess_info = NULL)
-  class(out) <- "TwinDKP"; out
+
+  local_indices <- twin_local_indices_rcpp(
+    Xtrain_norm = Xnorm,
+    Xquery_norm = Xnorm,
+    g_indices = g_indices,
+    l = l,
+    leaf_size = leaf_size
+  )
+
+  # ---- Compute posterior parameters ----
+  posterior <- .twindkp_compute_posterior(
+    Xquery_norm = Xnorm,
+    Xtrain_norm = Xnorm,
+    Y = Y,
+    g_indices = g_indices,
+    local_indices = local_indices,
+    theta_g = theta_g,
+    theta_l = theta_l,
+    global_kernel = global_kernel,
+    local_kernel = local_kernel,
+    isotropic = isotropic,
+    prior = prior,
+    r0 = r0,
+    p0 = p0,
+    store_kernel = store_kernel
+  )
+
+  # ---- Construct and return fitted model ----
+  out <- list(
+    theta_opt = theta_g,
+    theta_g = theta_g,
+    theta_l = theta_l,
+    kernel = global_kernel,
+    global_kernel = global_kernel,
+    local_kernel = local_kernel,
+    isotropic = isotropic,
+    loss = loss,
+    loss_min = loss_min,
+    X = X,
+    Xnorm = Xnorm,
+    Xbounds = Xbounds,
+    Y = Y,
+    prior = prior,
+    r0 = r0,
+    p0 = p0,
+    alpha0 = posterior$alpha0,
+    alpha_n = posterior$alpha_n,
+    prob = posterior$prob,
+    global_indices = g_indices,
+    control = list(
+      g_target = g,
+      g = g_actual,
+      l = l,
+      r = r,
+      twins = twins,
+      u1 = u1,
+      leaf_size = leaf_size,
+      store_kernel = store_kernel
+    ),
+    diagnostics = list(
+      twin_info = twin_info,
+      K = posterior$K,
+      K_global = posterior$K_global,
+      K_local = posterior$K_local
+    ),
+    ess = "none",
+    ess_info = NULL
+  )
+  class(out) <- "TwinDKP"
+  out
 }
 
-.twindkp_compute_posterior <- function(Xquery_norm, Xtrain_norm, Y, g_indices, local_indices, theta_g, theta_l, global_kernel, local_kernel, isotropic, prior, r0, p0, store_kernel = FALSE) {
+.twindkp_compute_posterior <- function(Xquery_norm, Xtrain_norm, Y, g_indices,
+                                       local_indices, theta_g, theta_l,
+                                       global_kernel, local_kernel, isotropic,
+                                       prior, r0, p0, store_kernel = FALSE) {
   twin_dkp_posterior_rcpp(
     Xquery_norm = Xquery_norm,
     Xtrain_norm = Xtrain_norm,

--- a/R/fitted_TwinDKP.R
+++ b/R/fitted_TwinDKP.R
@@ -2,4 +2,6 @@
 #' @keywords TwinDKP
 #' @export
 #' @method fitted TwinDKP
-fitted.TwinDKP <- function(object, ...) object$alpha_n / rowSums(object$alpha_n)
+fitted.TwinDKP <- function(object, ...) {
+  object$alpha_n / rowSums(object$alpha_n)
+}

--- a/R/predict_TwinDKP.R
+++ b/R/predict_TwinDKP.R
@@ -5,47 +5,155 @@
 predict.TwinDKP <- function(object, Xnew = NULL, CI_level = 0.95,
                             type = c("probability", "count"),
                             Mnew = NULL, ...) {
-  d <- ncol(object$X); type <- match.arg(type)
+  X <- object$X
+  d <- ncol(X)
+  type <- match.arg(type)
+
+  # ---- Check and format Xnew ----
   if (!is.null(Xnew)) {
-    if (is.null(dim(Xnew))) Xnew <- if (d == 1L) matrix(Xnew, ncol = 1L) else matrix(Xnew, nrow = 1L) else Xnew <- as.matrix(Xnew)
-    if (!is.numeric(Xnew)) stop("'Xnew' must be numeric.")
-    if (ncol(Xnew) != d) stop("The number of columns in 'Xnew' must match the original input dimension.")
-    if (anyNA(Xnew) || any(!is.finite(Xnew))) stop("'Xnew' must contain only finite values with no NA, NaN, or Inf.")
+    if (is.null(dim(Xnew))) {
+      if (d == 1L) {
+        Xnew <- matrix(Xnew, ncol = 1L)
+      } else {
+        Xnew <- matrix(Xnew, nrow = 1L)
+      }
+    } else {
+      Xnew <- as.matrix(Xnew)
+    }
+
+    if (!is.numeric(Xnew)) {
+      stop("'Xnew' must be numeric.")
+    }
+    if (ncol(Xnew) != d) {
+      stop("The number of columns in 'Xnew' must match the original input dimension.")
+    }
+    if (anyNA(Xnew) || any(!is.finite(Xnew))) {
+      stop("'Xnew' must contain only finite values with no NA, NaN, or Inf.")
+    }
   }
-  n_pred <- if (is.null(Xnew)) nrow(object$X) else nrow(Xnew)
-  if (!is.numeric(CI_level) || length(CI_level) != 1 || CI_level <= 0 || CI_level >= 1) stop("'CI_level' must be a single numeric value strictly between 0 and 1.")
+
+  n_pred <- if (is.null(Xnew)) nrow(X) else nrow(Xnew)
+
+  if (!is.numeric(CI_level) || length(CI_level) != 1 ||
+      CI_level <= 0 || CI_level >= 1) {
+    stop("'CI_level' must be a single numeric value strictly between 0 and 1.")
+  }
+
+  # ---- Check Mnew for count prediction ----
   if (type == "count") {
-    if (is.null(Mnew)) { if (is.null(Xnew)) Mnew <- rowSums(object$Y) else stop("When type = 'count' and Xnew is provided, 'Mnew' must also be provided.") }
-    if (!is.numeric(Mnew) || !(length(Mnew) == 1L || length(Mnew) == n_pred) || anyNA(Mnew) || any(!is.finite(Mnew)) || any(Mnew <= 0) || any(Mnew != floor(Mnew))) stop("'Mnew' must contain positive integers and have length 1 or the same length as the number of prediction points.")
+    if (is.null(Mnew)) {
+      if (is.null(Xnew)) {
+        Mnew <- rowSums(object$Y)
+      } else {
+        stop("When type = 'count' and Xnew is provided, 'Mnew' must also be provided.")
+      }
+    }
+
+    if (!is.numeric(Mnew)) {
+      stop("'Mnew' must be a numeric vector when type = 'count'.")
+    }
+    if (!(length(Mnew) == 1L || length(Mnew) == n_pred)) {
+      stop("'Mnew' must have length 1 or the same length as the number of prediction points.")
+    }
+    if (anyNA(Mnew) || any(!is.finite(Mnew))) {
+      stop("'Mnew' must contain finite values with no NA.")
+    }
+    if (any(Mnew <= 0) || any(Mnew != floor(Mnew))) {
+      stop("'Mnew' must contain positive integers when type = 'count'.")
+    }
+
     Mnew <- as.integer(if (length(Mnew) == 1L) rep.int(Mnew, n_pred) else Mnew)
   }
-  if (is.null(Xnew)) alpha_n <- object$alpha_n else {
-    Xnew_norm <- sweep(sweep(Xnew, 2, object$Xbounds[,1], "-"), 2, object$Xbounds[,2] - object$Xbounds[,1], "/")
-    local_indices <- twin_local_indices_rcpp(object$Xnorm, Xnew_norm, object$global_indices, object$control$l, if (is.null(object$control$leaf_size)) 8L else object$control$leaf_size)
-    alpha_n <- .twindkp_compute_posterior(Xnew_norm, object$Xnorm, object$Y, object$global_indices, local_indices, object$theta_g, object$theta_l, object$global_kernel, object$local_kernel, object$isotropic, object$prior, object$r0, object$p0, FALSE)$alpha_n
+
+  # ---- Posterior parameters ----
+  if (is.null(Xnew)) {
+    alpha_n <- object$alpha_n
+  } else {
+    Xnew_norm <- sweep(Xnew, 2, object$Xbounds[, 1], "-")
+    Xnew_norm <- sweep(Xnew_norm, 2, object$Xbounds[, 2] - object$Xbounds[, 1], "/")
+
+    leaf_size <- if (is.null(object$control$leaf_size)) 8L else object$control$leaf_size
+    local_indices <- twin_local_indices_rcpp(
+      Xtrain_norm = object$Xnorm,
+      Xquery_norm = Xnew_norm,
+      g_indices = object$global_indices,
+      l = object$control$l,
+      leaf_size = leaf_size
+    )
+
+    posterior <- .twindkp_compute_posterior(
+      Xquery_norm = Xnew_norm,
+      Xtrain_norm = object$Xnorm,
+      Y = object$Y,
+      g_indices = object$global_indices,
+      local_indices = local_indices,
+      theta_g = object$theta_g,
+      theta_l = object$theta_l,
+      global_kernel = object$global_kernel,
+      local_kernel = object$local_kernel,
+      isotropic = object$isotropic,
+      prior = object$prior,
+      r0 = object$r0,
+      p0 = object$p0,
+      store_kernel = FALSE
+    )
+    alpha_n <- posterior$alpha_n
   }
+
+  # ---- Posterior / posterior predictive summaries ----
   alpha_n <- as.matrix(alpha_n)
   if (anyNA(alpha_n) || any(!is.finite(alpha_n)) || any(alpha_n <= 0)) {
     stop("Posterior concentration parameters 'alpha_n' must be positive and finite.")
   }
+
   A <- rowSums(alpha_n)
   if (anyNA(A) || any(!is.finite(A)) || any(A <= 0)) {
     stop("Posterior concentration row sums must be positive and finite.")
   }
-  Amat <- matrix(A, nrow(alpha_n), ncol(alpha_n)); beta_n <- Amat - alpha_n
-  prob_mean <- alpha_n / Amat; prob_var <- prob_mean * (1 - prob_mean) / (Amat + 1)
+
+  Amat <- matrix(A, nrow(alpha_n), ncol(alpha_n))
+  beta_n <- Amat - alpha_n
+  prob_mean <- alpha_n / Amat
+  prob_var <- prob_mean * (1 - prob_mean) / (Amat + 1)
+
   class_names <- paste0("class", seq_len(ncol(alpha_n)))
+
   if (type == "probability") {
     pred_mean <- prob_mean
     pred_var <- prob_var
     pred_lower <- qbeta((1 - CI_level) / 2, alpha_n, beta_n)
     pred_upper <- qbeta((1 + CI_level) / 2, alpha_n, beta_n)
   } else {
-    Mmat <- matrix(Mnew, nrow(alpha_n), ncol(alpha_n)); pred_mean <- Mmat * prob_mean; pred_var <- Mmat * (Amat + Mmat) * prob_var
-    pred_lower <- matrix(qbetabinom_rcpp((1 - CI_level) / 2, as.vector(Mmat), as.vector(alpha_n), as.vector(beta_n)), nrow(alpha_n), ncol(alpha_n))
-    pred_upper <- matrix(qbetabinom_rcpp((1 + CI_level) / 2, as.vector(Mmat), as.vector(alpha_n), as.vector(beta_n)), nrow(alpha_n), ncol(alpha_n))
+    Mmat <- matrix(Mnew, nrow(alpha_n), ncol(alpha_n))
+    pred_mean <- Mmat * prob_mean
+    pred_var <- Mmat * (Amat + Mmat) * prob_var
+    pred_lower <- matrix(
+      qbetabinom_rcpp(
+        (1 - CI_level) / 2,
+        as.vector(Mmat),
+        as.vector(alpha_n),
+        as.vector(beta_n)
+      ),
+      nrow(alpha_n),
+      ncol(alpha_n)
+    )
+    pred_upper <- matrix(
+      qbetabinom_rcpp(
+        (1 + CI_level) / 2,
+        as.vector(Mmat),
+        as.vector(alpha_n),
+        as.vector(beta_n)
+      ),
+      nrow(alpha_n),
+      ncol(alpha_n)
+    )
   }
-  colnames(pred_mean) <- colnames(pred_var) <- colnames(pred_lower) <- colnames(pred_upper) <- class_names
+
+  colnames(pred_mean) <- class_names
+  colnames(pred_var) <- class_names
+  colnames(pred_lower) <- class_names
+  colnames(pred_upper) <- class_names
+
   out <- list(
     X = object$X,
     Xnew = Xnew,
@@ -56,11 +164,13 @@ predict.TwinDKP <- function(object, Xnew = NULL, CI_level = 0.95,
     upper = pred_upper,
     CI_level = CI_level,
     type = type,
-    class = max.col(prob_mean),
-    ess = "none"
+    ess = "none",
+    ess_info = NULL
   )
 
-  if (type == "count") out$Mnew <- Mnew
+  if (type == "count") {
+    out$Mnew <- Mnew
+  }
   class(out) <- "predict_TwinDKP"
   out
 }

--- a/R/print_TwinDKP.R
+++ b/R/print_TwinDKP.R
@@ -7,25 +7,57 @@ print.TwinDKP <- function(x, ...) {
   cat(sprintf("Number of observations (n): %d\n", nrow(x$X)))
   cat(sprintf("Input dimension (d):        %d\n", ncol(x$X)))
   cat(sprintf("Number of classes (q):      %d\n", ncol(x$Y)))
-  cat(sprintf("Global kernel:              %s\n", x$global_kernel)); cat(sprintf("Local kernel:               %s\n", x$local_kernel))
+  cat(sprintf("Global kernel:              %s\n", x$global_kernel))
+  cat(sprintf("Local kernel:               %s\n", x$local_kernel))
   cat(sprintf("Isotropic:                  %s\n", ifelse(x$isotropic, "TRUE", "FALSE")))
-  cat(sprintf("theta_g:                    %s\n", paste(round(x$theta_g, 4), collapse = ", "))); cat(sprintf("theta_l:                    %.4f\n", x$theta_l))
-  cat(sprintf("Loss function:              %s\n", x$loss)); cat(sprintf("Loss minimum:               %.5f\n", x$loss_min))
-  cat(sprintf("Prior:                      %s\n", x$prior)); cat(sprintf("Global subset size (g):     %d (target %d)\n", length(x$global_indices), x$control$g_target))
-  cat(sprintf("Local neighbours (l):       %d\n", x$control$l)); cat(sprintf("Twins runs:                 %d\n", x$control$twins)); invisible(x)
+  cat(sprintf("theta_g:                    %s\n", paste(round(x$theta_g, 4), collapse = ", ")))
+  cat(sprintf("theta_l:                    %.4f\n", x$theta_l))
+  cat(sprintf("Loss function:              %s\n", x$loss))
+  cat(sprintf("Loss minimum:               %.5f\n", x$loss_min))
+  cat(sprintf("Prior:                      %s\n", x$prior))
+  cat(sprintf(
+    "Global subset size (g):     %d (target %d)\n",
+    length(x$global_indices), x$control$g_target
+  ))
+  cat(sprintf("Local neighbours (l):       %d\n", x$control$l))
+  cat(sprintf("Twins runs:                 %d\n", x$control$twins))
+  invisible(x)
 }
+
 #' @rdname print
 #' @keywords TwinDKP
 #' @export
 #' @method print predict_TwinDKP
-print.predict_TwinDKP <- function(x, ...) { cat(if (is.null(x$Xnew)) "\nTwinDKP prediction on training data\n" else "\nTwinDKP prediction on new data\n"); print(head(x$mean)); invisible(x) }
+print.predict_TwinDKP <- function(x, ...) {
+  if (is.null(x$Xnew)) {
+    cat("\nTwinDKP prediction on training data\n")
+  } else {
+    cat("\nTwinDKP prediction on new data\n")
+  }
+  print(head(x$mean))
+  invisible(x)
+}
+
 #' @rdname print
 #' @keywords TwinDKP
 #' @export
 #' @method print summary_TwinDKP
-print.summary_TwinDKP <- function(x, ...) { cat("\n   Twin Dirichlet Kernel Process (TwinDKP) Model\n\n"); cat(sprintf("Number of observations (n): %d\n", x$n_obs)); cat(sprintf("Input dimension (d):        %d\n", x$input_dim)); cat(sprintf("Number of classes (q):      %d\n", x$n_classes)); cat(sprintf("Global subset size (g):     %d\n", x$global_size)); cat(sprintf("Local neighbours (l):       %d\n", x$local_size)); invisible(x) }
+print.summary_TwinDKP <- function(x, ...) {
+  cat("\n   Twin Dirichlet Kernel Process (TwinDKP) Model\n\n")
+  cat(sprintf("Number of observations (n): %d\n", x$n_obs))
+  cat(sprintf("Input dimension (d):        %d\n", x$input_dim))
+  cat(sprintf("Number of classes (q):      %d\n", x$n_classes))
+  cat(sprintf("Global subset size (g):     %d\n", x$global_size))
+  cat(sprintf("Local neighbours (l):       %d\n", x$local_size))
+  invisible(x)
+}
+
 #' @rdname print
 #' @keywords TwinDKP
 #' @export
 #' @method print simulate_TwinDKP
-print.simulate_TwinDKP <- function(x, ...) { cat("\nTwinDKP posterior simulation\n"); print(dim(x$samples)); invisible(x) }
+print.simulate_TwinDKP <- function(x, ...) {
+  cat("\nTwinDKP posterior simulation\n")
+  print(dim(x$samples))
+  invisible(x)
+}

--- a/R/quantile_TwinDKP.R
+++ b/R/quantile_TwinDKP.R
@@ -2,4 +2,6 @@
 #' @keywords TwinDKP
 #' @export
 #' @method quantile TwinDKP
-quantile.TwinDKP <- function(x, probs = c(0.025, 0.5, 0.975), ...) quantile.DKP(x, probs = probs, ...)
+quantile.TwinDKP <- function(x, probs = c(0.025, 0.5, 0.975), ...) {
+  quantile.DKP(x, probs = probs, ...)
+}

--- a/R/simulate_TwinDKP.R
+++ b/R/simulate_TwinDKP.R
@@ -28,7 +28,7 @@ simulate.TwinDKP <- function(object, nsim = 1, seed = NULL,
   q <- ncol(alpha_n)
   samples <- array(0, c(n_new, q, as.integer(nsim)))
   for (i in seq_len(n_new)) {
-    samples[i,,] <- t(rdirichlet(as.integer(nsim), alpha_n[i, ]))
+    samples[i, , ] <- t(rdirichlet(as.integer(nsim), alpha_n[i, ]))
   }
   dimnames(samples) <- list(
     paste0("x", seq_len(n_new)),
@@ -41,7 +41,8 @@ simulate.TwinDKP <- function(object, nsim = 1, seed = NULL,
     class = apply(samples, 3, max.col),
     X = object$X,
     Xnew = Xnew,
-    ess = "none")
+    ess = "none"
+  )
   class(out) <- "simulate_TwinDKP"
   out
 }

--- a/R/summary_TwinDKP.R
+++ b/R/summary_TwinDKP.R
@@ -24,7 +24,8 @@ summary.TwinDKP <- function(object, ...) {
     global_target = object$control$g_target,
     local_size = object$control$l,
     twins = object$control$twins,
-    post_mean = prob)
+    post_mean = prob
+  )
   class(out) <- "summary_TwinDKP"
   out
 }

--- a/tests/testthat/helper-TwinDKP.R
+++ b/tests/testthat/helper-TwinDKP.R
@@ -6,7 +6,8 @@ make_twindkp_data <- function() {
   eta2 <- 0.2 + X[, 1]
   eta3 <- -0.5 + 1.5 * X[, 1]
   E <- cbind(eta1, eta2, eta3)
-  P <- exp(E); P <- P / rowSums(P)
+  P <- exp(E)
+  P <- P / rowSums(P)
   m <- rep(12, n)
   Y <- t(vapply(seq_len(n), function(i) as.numeric(rmultinom(1, size = m[i], prob = P[i, ])), numeric(3)))
   list(X = X, Y = Y)

--- a/tests/testthat/test-fit_TwinDKP.R
+++ b/tests/testthat/test-fit_TwinDKP.R
@@ -1,5 +1,6 @@
 test_that("fit_TwinDKP returns expected structure", {
-  fx <- make_twindkp_model_1d(); fit <- fx$model
+  fx <- make_twindkp_model_1d()
+  fit <- fx$model
   expect_s3_class(fit, "TwinDKP")
   expect_length(fit$global_indices, fit$control$g)
   expect_equal(fit$control$g_target, 10)
@@ -9,7 +10,8 @@ test_that("fit_TwinDKP returns expected structure", {
 test_that("fit_TwinDKP validates inputs", {
   fx <- make_twindkp_data()
   expect_error(fit_TwinDKP(fx$X, fx$Y, prior = "fixed", p0 = c(.5, .5), theta_g = .4, theta_l = .3, g = 10, l = 5), "p0")
-  badY <- fx$Y; badY[1, 1] <- -1
+  badY <- fx$Y
+  badY[1, 1] <- -1
   expect_error(fit_TwinDKP(fx$X, badY, theta_g = .4, theta_l = .3, g = 10, l = 5), "nonnegative")
   expect_error(fit_TwinDKP(fx$X, fx$Y, theta_g = .4, theta_l = .3, g = 10, l = 5, control = list(ess = "shepard")), "does not support ESS")
 })
@@ -17,13 +19,16 @@ test_that("fit_TwinDKP validates inputs", {
 .twindkp_dense_reference <- function(Xquery_norm, Xtrain_norm, Y, g_indices, local_indices,
                                      theta_g, theta_l, global_kernel, local_kernel,
                                      isotropic, prior, r0, p0) {
-  t <- nrow(Xquery_norm); n <- nrow(Xtrain_norm)
+  t <- nrow(Xquery_norm)
+  n <- nrow(Xtrain_norm)
   Kg <- kernel_matrix(Xquery_norm, Xtrain_norm[g_indices,, drop = FALSE], theta_g, global_kernel, isotropic)
-  Kfull_g <- matrix(0, t, n); Kfull_g[, g_indices] <- Kg
+  Kfull_g <- matrix(0, t, n)
+  Kfull_g[, g_indices] <- Kg
   Kfull_l <- matrix(0, t, n)
   if (ncol(local_indices) > 0L) {
     for (i in seq_len(t)) {
-      idx <- local_indices[i, ]; idx <- idx[idx > 0]
+      idx <- local_indices[i, ]
+      idx <- idx[idx > 0]
       if (length(idx)) {
         Kfull_l[i, idx] <- kernel_matrix(Xquery_norm[i,, drop = FALSE], Xtrain_norm[idx,, drop = FALSE], theta_l, local_kernel, TRUE)
       }

--- a/tests/testthat/test-predict_TwinDKP.R
+++ b/tests/testthat/test-predict_TwinDKP.R
@@ -1,16 +1,24 @@
-test_that("predict.TwinDKP returns probability, class, and count predictions", {
+test_that("predict.TwinDKP returns probability and count predictions", {
   fx <- make_twindkp_model_1d()
   fit <- fx$model
   Xnew <- matrix(c(0.2, 0.5, 0.8), ncol = 1)
-  p <- predict(fit, Xnew)
+
+  p <- predict(fit, Xnew, type = "probability")
   expect_s3_class(p, "predict_TwinDKP")
   expect_equal(dim(p$mean), c(3, 3))
   expect_equal(as.numeric(rowSums(p$mean)), rep(1, 3), tolerance = 1e-8)
-  cls <- predict(fit, Xnew, type = "probability")
-  expect_length(cls, 11)
+  expect_null(p$class)
+
   cnt <- predict(fit, Xnew, type = "count", Mnew = 12)
+  expect_s3_class(cnt, "predict_TwinDKP")
   expect_equal(dim(cnt$mean), c(3, 3))
+  expect_equal(dim(cnt$variance), c(3, 3))
+  expect_equal(dim(cnt$lower), c(3, 3))
+  expect_equal(dim(cnt$upper), c(3, 3))
+  expect_equal(cnt$Mnew, rep(12L, 3))
+  expect_null(cnt$class)
 })
+
 test_that("predict.TwinDKP validates Xnew", {
   fit <- make_twindkp_model_1d()$model
   expect_error(predict(fit, matrix(NA_real_, ncol = 1)), "finite")


### PR DESCRIPTION
### Motivation

- Improve readability and consistency of TwinDKP R code by applying one-statement-per-line formatting and section comments while keeping behavior unchanged.
- Remove an unnecessary `class` field from `predict.TwinDKP()` so the prediction object matches DKP style and does not return hard class labels.
- Preserve the efficient C++ posterior path (`twin_dkp_posterior_rcpp()`) and avoid reintroducing dense R posterior allocation.

### Description

- Reformatted TwinDKP implementation and helpers for readability, adding section comments and expanding compressed one-line statements in `R/fit_TwinDKP.R`, `R/predict_TwinDKP.R`, `R/summary_TwinDKP.R`, `R/print_TwinDKP.R`, `R/fitted_TwinDKP.R`, `R/parameter_TwinDKP.R`, `R/quantile_TwinDKP.R`, and `R/simulate_TwinDKP.R` while keeping behavior unchanged.
- Removed the `class = max.col(prob_mean)` entry from the list returned by `predict.TwinDKP()` and adjusted the returned list to include `ess_info = NULL` and only append `Mnew` when `type = "count"`.
- Kept the posterior wrapper ` .twindkp_compute_posterior()` that calls `twin_dkp_posterior_rcpp()` unchanged so the C++ posterior path remains used and no dense `t × n` allocations were reintroduced.
- Updated tests and helpers to reflect the removed `class` field and formatting changes, primarily `tests/testthat/test-predict_TwinDKP.R`, `tests/testthat/test-fit_TwinDKP.R`, and `tests/testthat/helper-TwinDKP.R`.

### Testing

- Searched for semicolon-compressed multi-statement lines with `grep` across TwinDKP R files and found none (passed).
- Verified presence of the C++ posterior call and absence of forbidden dense-allocation or `type = "class"` patterns via `rg`, confirming `twin_dkp_posterior_rcpp()` remains used and forbidden patterns are not present (passed).
- Ran `git diff --check` to ensure no whitespace or diff issues (passed).
- Could not run `devtools::document()`, `devtools::test()`, or `devtools::check()` because `Rscript` is not available in the environment, so unit tests were updated but not executed here (not run).

Files reformatted: `R/fit_TwinDKP.R`, `R/predict_TwinDKP.R`, `R/summary_TwinDKP.R`, `R/print_TwinDKP.R`, `R/fitted_TwinDKP.R`, `R/parameter_TwinDKP.R`, `R/quantile_TwinDKP.R`, `R/simulate_TwinDKP.R`, and test files `tests/testthat/test-predict_TwinDKP.R`, `tests/testthat/test-fit_TwinDKP.R`, `tests/testthat/helper-TwinDKP.R`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40cc3708d883209692dca57c57ed5b)