### PR TITLE
Control OpenMP threads in twinning backend

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,8 +41,8 @@ twin_dkp_posterior_rcpp <- function(Xquery_norm, Xtrain_norm, Y, g_indices, loca
     .Call(`_BKP_twin_dkp_posterior_rcpp`, Xquery_norm, Xtrain_norm, Y, g_indices, local_indices, theta_g, theta_l, global_kernel, local_kernel, isotropic, prior, r0, p0, store_kernel)
 }
 
-twin_select_global_rcpp <- function(twin_data, Xnorm, r, runs, u1, leaf_size = 8L) {
-    .Call(`_BKP_twin_select_global_rcpp`, twin_data, Xnorm, r, runs, u1, leaf_size)
+twin_select_global_rcpp <- function(twin_data, Xnorm, r, runs, u1, leaf_size = 8, n_threads = 1) {
+    .Call(`_BKP_twin_select_global_rcpp`, twin_data, Xnorm, r, runs, u1, leaf_size, n_threads)
 }
 
 twin_local_indices_rcpp <- function(Xtrain_norm, Xquery_norm, g_indices, l, leaf_size = 8L) {

--- a/R/fit_TwinBKP.R
+++ b/R/fit_TwinBKP.R
@@ -408,7 +408,8 @@ fit_TwinBKP <- function(
     r = r,
     runs = twins,
     u1 = u1,
-    leaf_size = leaf_size
+    leaf_size = leaf_size,
+    n_threads = n_threads
   )
 
   g_indices <- as.integer(twin_info$g_indices)

--- a/R/fit_TwinDKP.R
+++ b/R/fit_TwinDKP.R
@@ -409,7 +409,8 @@ fit_TwinDKP <- function(
     r = r,
     runs = twins,
     u1 = u1,
-    leaf_size = leaf_size
+    leaf_size = leaf_size,
+    n_threads = n_threads
   )
   g_indices <- as.integer(twin_info$g_indices)
   g_actual <- length(g_indices)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -206,8 +206,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // twin_select_global_rcpp
-Rcpp::List twin_select_global_rcpp(Rcpp::NumericMatrix twin_data, Rcpp::NumericMatrix Xnorm, std::size_t r, std::size_t runs, Rcpp::IntegerVector u1, std::size_t leaf_size);
-RcppExport SEXP _BKP_twin_select_global_rcpp(SEXP twin_dataSEXP, SEXP XnormSEXP, SEXP rSEXP, SEXP runsSEXP, SEXP u1SEXP, SEXP leaf_sizeSEXP) {
+Rcpp::List twin_select_global_rcpp(Rcpp::NumericMatrix twin_data, Rcpp::NumericMatrix Xnorm, std::size_t r, std::size_t runs, Rcpp::IntegerVector u1, std::size_t leaf_size, std::size_t n_threads);
+RcppExport SEXP _BKP_twin_select_global_rcpp(SEXP twin_dataSEXP, SEXP XnormSEXP, SEXP rSEXP, SEXP runsSEXP, SEXP u1SEXP, SEXP leaf_sizeSEXP, SEXP n_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -217,7 +217,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::size_t >::type runs(runsSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type u1(u1SEXP);
     Rcpp::traits::input_parameter< std::size_t >::type leaf_size(leaf_sizeSEXP);
-    rcpp_result_gen = Rcpp::wrap(twin_select_global_rcpp(twin_data, Xnorm, r, runs, u1, leaf_size));
+    Rcpp::traits::input_parameter< std::size_t >::type n_threads(n_threadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(twin_select_global_rcpp(twin_data, Xnorm, r, runs, u1, leaf_size, n_threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -248,7 +249,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_BKP_shepard_m_loo_rcpp", (DL_FUNC) &_BKP_shepard_m_loo_rcpp, 3},
     {"_BKP_twin_bkp_posterior_rcpp", (DL_FUNC) &_BKP_twin_bkp_posterior_rcpp, 15},
     {"_BKP_twin_dkp_posterior_rcpp", (DL_FUNC) &_BKP_twin_dkp_posterior_rcpp, 14},
-    {"_BKP_twin_select_global_rcpp", (DL_FUNC) &_BKP_twin_select_global_rcpp, 6},
+    {"_BKP_twin_select_global_rcpp", (DL_FUNC) &_BKP_twin_select_global_rcpp, 7},
     {"_BKP_twin_local_indices_rcpp", (DL_FUNC) &_BKP_twin_local_indices_rcpp, 5},
     {NULL, NULL, 0}
 };

--- a/src/twinning_bkp.cpp
+++ b/src/twinning_bkp.cpp
@@ -99,6 +99,7 @@ private:
   std::size_t runs_;
   std::vector<std::size_t> u1_;
   std::size_t leaf_size_;
+  std::size_t n_threads_;
 
   DF2 twin_data_;
   DF2 x_data_;
@@ -111,7 +112,8 @@ public:
     std::size_t r,
     std::size_t runs,
     std::vector<std::size_t>& u1,
-    std::size_t leaf_size)
+    std::size_t leaf_size,
+    std::size_t n_threads)
     :
     dim_twin_(twin_data.cols()),
     dim_x_(Xnorm.cols()),
@@ -119,7 +121,8 @@ public:
     r_(r),
     runs_(runs),
     u1_(u1),
-    leaf_size_(leaf_size)
+    leaf_size_(leaf_size),
+    n_threads_(std::max<std::size_t>(1, n_threads))
   {
     twin_data_.import_data(twin_data);
     x_data_.import_data(Xnorm);
@@ -133,7 +136,16 @@ public:
     all_indices.resize(runs_);
     min_dist.resize(runs_);
 
-#pragma omp parallel for
+    int n_threads_used = 1;
+#ifdef _OPENMP
+    n_threads_used = static_cast<int>(
+      std::max<std::size_t>(1, std::min<std::size_t>(n_threads_, runs_))
+    );
+#endif
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(n_threads_used)
+#endif
     for (std::size_t run = 0; run < runs_; run++)
     {
       kdTree tree(
@@ -200,6 +212,7 @@ public:
     returns_["theta_l"] = theta_l(g_indices0);
     returns_["min_dist"] = min_dist[max_index];
     returns_["best_run"] = max_index + 1;
+    returns_["n_threads"] = n_threads_used;
 
     return returns_;
   }
@@ -252,7 +265,16 @@ public:
     std::vector<double> distances;
     distances.resize(N_);
 
-#pragma omp parallel for
+    int n_threads_used = 1;
+#ifdef _OPENMP
+    n_threads_used = static_cast<int>(
+      std::max<std::size_t>(1, std::min<std::size_t>(n_threads_, N_))
+    );
+#endif
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) num_threads(n_threads_used)
+#endif
     for (std::size_t i = 0; i < N_; i++)
     {
       nanoflann::KNNResultSet<double> resultSet(1);
@@ -280,7 +302,8 @@ Rcpp::List twin_select_global_rcpp(
     std::size_t r,
     std::size_t runs,
     Rcpp::IntegerVector u1,
-    std::size_t leaf_size = 8)
+    std::size_t leaf_size = 8,
+    std::size_t n_threads = 1)
 {
   std::vector<std::size_t> u1_cpp(runs);
 
@@ -294,7 +317,8 @@ Rcpp::List twin_select_global_rcpp(
       r,
       runs,
       u1_cpp,
-      leaf_size
+      leaf_size,
+      n_threads
   );
 
   return tree.twin();

--- a/tests/testthat/test-fit_TwinBKP.R
+++ b/tests/testthat/test-fit_TwinBKP.R
@@ -495,3 +495,26 @@ test_that("fit_TwinBKP can optimize theta_g on a small global subset", {
   expect_true(all(model$theta_g > 0))
   expect_true(is.finite(model$loss_min))
 })
+
+test_that("fit_TwinBKP passes n_threads to twinning backend", {
+  set.seed(123)
+  X <- matrix(seq(0, 1, length.out = 30), ncol = 1)
+  m <- rep(10, 30)
+  y <- rbinom(30, size = m, prob = 0.4 + 0.2 * X[, 1])
+
+  fit <- fit_TwinBKP(
+    X, y, m,
+    theta_g = 0.3,
+    g = 8,
+    l = 3,
+    twins = 2,
+    n_threads = 1
+  )
+
+  expect_s3_class(fit, "TwinBKP")
+  expect_equal(fit$control$n_threads, 1L)
+
+  if (!is.null(fit$diagnostics$twin_info$n_threads)) {
+    expect_equal(as.integer(fit$diagnostics$twin_info$n_threads), 1L)
+  }
+})

--- a/tests/testthat/test-fit_TwinDKP.R
+++ b/tests/testthat/test-fit_TwinDKP.R
@@ -119,3 +119,30 @@ test_that("fit_TwinDKP validates fixed p0 consistently", {
   expect_error(fit_TwinDKP(fx$X, fx$Y, prior = "fixed", p0 = c(.5, NaN, .5), theta_g = .4, theta_l = .3, g = 10, l = 5), "p0")
   expect_error(fit_TwinDKP(fx$X, fx$Y, prior = "fixed", p0 = c(.5, Inf, .5), theta_g = .4, theta_l = .3, g = 10, l = 5), "p0")
 })
+
+test_that("fit_TwinDKP passes n_threads to twinning backend", {
+  set.seed(123)
+  X <- matrix(seq(0, 1, length.out = 30), ncol = 1)
+  p1 <- 0.3 + 0.2 * X[, 1]
+  p2 <- 1 - p1
+
+  Y <- t(vapply(seq_len(30), function(i) {
+    as.vector(rmultinom(1, size = 10, prob = c(p1[i], p2[i])))
+  }, numeric(2)))
+
+  fit <- fit_TwinDKP(
+    X, Y,
+    theta_g = 0.3,
+    g = 8,
+    l = 3,
+    twins = 2,
+    n_threads = 1
+  )
+
+  expect_s3_class(fit, "TwinDKP")
+  expect_equal(fit$control$n_threads, 1L)
+
+  if (!is.null(fit$diagnostics$twin_info$n_threads)) {
+    expect_equal(as.integer(fit$diagnostics$twin_info$n_threads), 1L)
+  }
+})


### PR DESCRIPTION
### Motivation
- Prevent uncontrolled OpenMP parallelism in the twinning backend that caused CRAN CPU/elapsed ratio NOTES by making twinning and theta_l computations respect the package `n_threads` control.
- Keep statistical behaviour and OpenMP support unchanged while ensuring `n_threads = 1` forces single-threaded execution of explicit OpenMP loops.

### Description
- Added a `n_threads_` member to `BKPTwinKDTree` and accept `n_threads` in its constructor, sanitising it with `std::max(1, n_threads)`. (modified `src/twinning_bkp.cpp`)
- Replaced bare `#pragma omp parallel for` loops in the global twinning loop and in `theta_l()` with guarded pragmas that compute `n_threads_used` and use `num_threads(n_threads_used)` plus explicit schedules (`dynamic` for twinning, `static` for theta_l). (modified `src/twinning_bkp.cpp`)
- Extended `twin_select_global_rcpp()` to accept `n_threads` and pass it into `BKPTwinKDTree`, and threaded the existing R-level `n_threads` through `fit_TwinBKP()` and `fit_TwinDKP()` calls to the backend. (modified `src/twinning_bkp.cpp`, `R/fit_TwinBKP.R`, `R/fit_TwinDKP.R`)
- Updated Rcpp export wrappers/registration to include the new `n_threads` argument so `.Call` signatures match the C++ changes; `R/RcppExports.R` and `src/RcppExports.cpp` were adjusted to reflect the new parameter. (modified `R/RcppExports.R`, `src/RcppExports.cpp`)
- Added small testthat tests that assert `fit_TwinBKP(..., n_threads = 1)` and `fit_TwinDKP(..., n_threads = 1)` preserve `control$n_threads` and surface `diagnostics$twin_info$n_threads` when present. (modified `tests/testthat/test-fit_TwinBKP.R`, `tests/testthat/test-fit_TwinDKP.R`)

### Testing
- Ran static checks including `git diff --check` and searched for remaining bare OpenMP pragmas with `rg`, confirming the explicit `#pragma omp parallel for` occurrences were replaced by guarded pragmas using `num_threads(...)` (search succeeded).
- Could not run `Rcpp::compileAttributes()`, `devtools::document()`, `devtools::test()` or `rcmdcheck::rcmdcheck()` in this environment because `Rscript` is not installed here, so the new tests were added but not executed in this run.
- Manually updated Rcpp wrapper files to match the expected `Rcpp::compileAttributes()` output since `Rscript` was unavailable, and validated the exported signatures reference the new `n_threads` parameter via source inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44be0fe2e0832096939be5b03ab67f)