### PR TITLE
Update examples: use smaller fixed thetas for runnable examples and realistic dontrun Twin examples

### DIFF
--- a/R/fit_BKP.R
+++ b/R/fit_BKP.R
@@ -149,7 +149,9 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model1 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model1 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #' print(model1)
 #'
 #'
@@ -178,7 +180,9 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model2 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model2 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.08)
 #' print(model2)
 #'
 #' @export

--- a/R/fit_DKP.R
+++ b/R/fit_DKP.R
@@ -126,7 +126,9 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model1 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model1 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #' print(model1)
 #'
 #'
@@ -157,7 +159,9 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model2 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model2 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.08)
 #' print(model2)
 #'
 #' @export

--- a/R/fit_TwinBKP.R
+++ b/R/fit_TwinBKP.R
@@ -172,10 +172,12 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit TwinBKP model
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
 #' model1 <- fit_TwinBKP(
 #'      X, y, m,
 #'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
+#'      theta_g = 0.04,
 #'      g = 20,
 #'      twins = 1,
 #'      n_threads = 1
@@ -206,10 +208,12 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit TwinBKP model
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
 #' model2 <- fit_TwinBKP(
 #'      X, y, m,
 #'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
+#'      theta_g = 0.08,
 #'      g = 20,
 #'      twins = 1,
 #'      n_threads = 1

--- a/R/fit_TwinDKP.R
+++ b/R/fit_TwinDKP.R
@@ -173,10 +173,12 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit TwinDKP model
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
 #' model1 <- fit_TwinDKP(
 #'      X, Y,
 #'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
+#'      theta_g = 0.04,
 #'      g = 20,
 #'      twins = 1,
 #'      n_threads = 1
@@ -211,10 +213,12 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit TwinDKP model
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
 #' model2 <- fit_TwinDKP(
 #'      X, Y,
 #'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
+#'      theta_g = 0.08,
 #'      g = 20,
 #'      twins = 1,
 #'      n_threads = 1

--- a/R/fitted_BKP.R
+++ b/R/fitted_BKP.R
@@ -54,27 +54,25 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Extract fitted values
 #' fitted(model)
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Extract fitted values

--- a/R/fitted_DKP.R
+++ b/R/fitted_DKP.R
@@ -20,14 +20,16 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Extract fitted values
 #' fitted(model)
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(150, n, replace = TRUE)
@@ -35,14 +37,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Extract fitted values

--- a/R/parameter_BKP.R
+++ b/R/parameter_BKP.R
@@ -55,27 +55,25 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Extract posterior parameters
 #' parameter(model)
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Extract posterior and kernel parameters

--- a/R/parameter_DKP.R
+++ b/R/parameter_DKP.R
@@ -21,14 +21,16 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Extract model parameters
 #' parameter(model)
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(150, n, replace = TRUE)
@@ -36,14 +38,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Extract posterior and kernel parameters

--- a/R/plot_BKP.R
+++ b/R/plot_BKP.R
@@ -118,7 +118,7 @@
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model1 <- fit_TwinBKP(X, y, m, Xbounds = Xbounds)
 #'
 #' # Plot results
@@ -165,7 +165,7 @@
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model2 <- fit_TwinBKP(X, y, m, Xbounds = Xbounds)
 #'
 #' # Plot results

--- a/R/plot_DKP.R
+++ b/R/plot_DKP.R
@@ -39,7 +39,7 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model1 <- fit_TwinDKP(X, Y, Xbounds = Xbounds)
 #'
 #' # Plot results
@@ -90,7 +90,7 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model2 <- fit_TwinDKP(X, Y, Xbounds = Xbounds)
 #'
 #' # Plot results

--- a/R/predict_BKP.R
+++ b/R/predict_BKP.R
@@ -161,7 +161,9 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Prediction on training data
 #' predict(model)
@@ -176,20 +178,16 @@
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Prediction on training data

--- a/R/predict_DKP.R
+++ b/R/predict_DKP.R
@@ -21,7 +21,9 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Prediction on training data
 #' predict(model)
@@ -36,7 +38,7 @@
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(150, n, replace = TRUE)
@@ -44,14 +46,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Prediction on training data

--- a/R/print_BKP.R
+++ b/R/print_BKP.R
@@ -61,7 +61,9 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #' print(model)                    # fitted object
 #' print(summary(model))           # summary
 #' print(predict(model))           # predictions
@@ -69,20 +71,16 @@
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #' print(model)                    # fitted object
 #' print(summary(model))           # summary

--- a/R/print_DKP.R
+++ b/R/print_DKP.R
@@ -21,7 +21,9 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #' print(model)                    # fitted object
 #' print(summary(model))           # summary
 #' print(predict(model))           # predictions
@@ -29,7 +31,7 @@
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(150, n, replace = TRUE)
@@ -37,14 +39,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #' print(model)                    # fitted object
 #' print(summary(model))           # summary

--- a/R/quantile_BKP.R
+++ b/R/quantile_BKP.R
@@ -62,27 +62,25 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Extract posterior quantiles
 #' quantile(model)
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Extract posterior quantiles

--- a/R/quantile_DKP.R
+++ b/R/quantile_DKP.R
@@ -20,14 +20,16 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Extract posterior quantiles
 #' quantile(model)
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
@@ -35,14 +37,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Extract posterior quantiles

--- a/R/simulate_BKP.R
+++ b/R/simulate_BKP.R
@@ -97,7 +97,9 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Simulate 5 posterior draws of success probabilities
 #' Xnew <- matrix(seq(-2, 2, length.out = 5), ncol = 1)
@@ -108,20 +110,16 @@
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Simulate 5 posterior draws of success probabilities

--- a/R/simulate_DKP.R
+++ b/R/simulate_DKP.R
@@ -21,7 +21,9 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #'
 #' # Simulate 5 draws from posterior Dirichlet distributions at new point
 #' Xnew <- matrix(seq(-2, 2, length.out = 5), ncol = 1)
@@ -29,7 +31,7 @@
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(150, n, replace = TRUE)
@@ -37,14 +39,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #'
 #' # Simulate 5 draws from posterior Dirichlet distributions at new point

--- a/R/summary_BKP.R
+++ b/R/summary_BKP.R
@@ -60,25 +60,23 @@
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
 #' # Fit BKP model
-#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 #' summary(model)
 #'
 #' \dontrun{
 #' # Larger TwinBKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(100, n, replace = TRUE)
 #' y <- rbinom(n, size = m, prob = true_pi)
 #'
-#' # Fit TwinBKP model
+#' # Fit TwinBKP model using the default global lengthscale tuning
 #' model <- fit_TwinBKP(
 #'      X, y, m,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #' summary(model)
 #' }

--- a/R/summary_DKP.R
+++ b/R/summary_DKP.R
@@ -21,12 +21,14 @@
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
 #' # Fit DKP model
-#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+#' # A fixed theta is used here only to keep the example fast and reproducible.
+#' # In practice, omit theta to select it by leave-one-out cross-validation.
+#' model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 #' summary(model)
 #'
 #' \dontrun{
 #' # Larger TwinDKP example
-#' n <- 200
+#' n <- 1000
 #' X <- tgp::lhs(n = n, rect = Xbounds)
 #' true_pi <- true_pi_fun(X)
 #' m <- sample(150, n, replace = TRUE)
@@ -34,14 +36,10 @@
 #' # Generate multinomial responses
 #' Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 #'
-#' # Fit TwinDKP model
+#' # Fit TwinDKP model using the default global lengthscale tuning
 #' model <- fit_TwinDKP(
 #'      X, Y,
-#'      Xbounds = Xbounds,
-#'      theta_g = 0.3,
-#'      g = 20,
-#'      twins = 1,
-#'      n_threads = 1
+#'      Xbounds = Xbounds
 #'    )
 #' summary(model)
 #' }

--- a/man/fit_BKP.Rd
+++ b/man/fit_BKP.Rd
@@ -176,7 +176,9 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model1 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model1 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 print(model1)
 
 
@@ -205,7 +207,9 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model2 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model2 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.08)
 print(model2)
 
 }

--- a/man/fit_DKP.Rd
+++ b/man/fit_DKP.Rd
@@ -182,7 +182,9 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model1 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model1 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 print(model1)
 
 
@@ -213,7 +215,9 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model2 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model2 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.08)
 print(model2)
 
 }

--- a/man/fit_TwinBKP.Rd
+++ b/man/fit_TwinBKP.Rd
@@ -216,10 +216,12 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit TwinBKP model
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
 model1 <- fit_TwinBKP(
      X, y, m,
      Xbounds = Xbounds,
-     theta_g = 0.3,
+     theta_g = 0.04,
      g = 20,
      twins = 1,
      n_threads = 1
@@ -250,10 +252,12 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit TwinBKP model
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
 model2 <- fit_TwinBKP(
      X, y, m,
      Xbounds = Xbounds,
-     theta_g = 0.3,
+     theta_g = 0.08,
      g = 20,
      twins = 1,
      n_threads = 1

--- a/man/fit_TwinDKP.Rd
+++ b/man/fit_TwinDKP.Rd
@@ -218,10 +218,12 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit TwinDKP model
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
 model1 <- fit_TwinDKP(
      X, Y,
      Xbounds = Xbounds,
-     theta_g = 0.3,
+     theta_g = 0.04,
      g = 20,
      twins = 1,
      n_threads = 1
@@ -256,10 +258,12 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit TwinDKP model
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
 model2 <- fit_TwinDKP(
      X, Y,
      Xbounds = Xbounds,
-     theta_g = 0.3,
+     theta_g = 0.08,
      g = 20,
      twins = 1,
      n_threads = 1

--- a/man/fitted.Rd
+++ b/man/fitted.Rd
@@ -65,27 +65,25 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 
 # Extract fitted values
 fitted(model)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Extract fitted values
@@ -110,14 +108,16 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 
 # Extract fitted values
 fitted(model)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -125,14 +125,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Extract fitted values

--- a/man/parameter.Rd
+++ b/man/parameter.Rd
@@ -67,27 +67,25 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 
 # Extract posterior parameters
 parameter(model)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Extract posterior and kernel parameters
@@ -112,14 +110,16 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 
 # Extract model parameters
 parameter(model)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -127,14 +127,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Extract posterior and kernel parameters

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -146,27 +146,25 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model1 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model1 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 
 # Plot results
 plot(model1)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model1 <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Plot results
@@ -198,27 +196,25 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model2 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model2 <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.08)
 
 # Plot results
 plot(model2)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model2 <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Plot results
@@ -244,14 +240,16 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model1 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model1 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 
 # Plot results
 plot(model1)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -259,14 +257,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model1 <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Plot results
@@ -300,14 +294,16 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model2 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model2 <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.08)
 
 # Plot results
 plot(model2)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -315,14 +311,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model2 <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Plot results

--- a/man/predict.Rd
+++ b/man/predict.Rd
@@ -205,7 +205,9 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 
 # Prediction on training data
 predict(model)
@@ -220,20 +222,16 @@ predict(model, Xnew = Xnew, type = "count", Mnew = Mnew)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Prediction on training data
@@ -264,7 +262,9 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 
 # Prediction on training data
 predict(model)
@@ -279,7 +279,7 @@ predict(model, Xnew = Xnew, type = "count", Mnew = Mnew)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -287,14 +287,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Prediction on training data

--- a/man/print.Rd
+++ b/man/print.Rd
@@ -101,7 +101,9 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 print(model)                    # fitted object
 print(summary(model))           # summary
 print(predict(model))           # predictions
@@ -109,20 +111,16 @@ print(simulate(model, nsim = 3))  # posterior simulations
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 print(model)                    # fitted object
 print(summary(model))           # summary
@@ -148,7 +146,9 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 print(model)                    # fitted object
 print(summary(model))           # summary
 print(predict(model))           # predictions
@@ -156,7 +156,7 @@ print(simulate(model, nsim = 3))  # posterior simulations
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -164,14 +164,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 print(model)                    # fitted object
 print(summary(model))           # summary

--- a/man/quantile.Rd
+++ b/man/quantile.Rd
@@ -72,27 +72,25 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 
 # Extract posterior quantiles
 quantile(model)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Extract posterior quantiles
@@ -117,14 +115,16 @@ m <- sample(100, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 
 # Extract posterior quantiles
 quantile(model)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
@@ -132,14 +132,10 @@ m <- sample(100, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Extract posterior quantiles

--- a/man/simulate.Rd
+++ b/man/simulate.Rd
@@ -109,7 +109,9 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 
 # Simulate 5 posterior draws of success probabilities
 Xnew <- matrix(seq(-2, 2, length.out = 5), ncol = 1)
@@ -120,20 +122,16 @@ simulate(model, Xnew = Xnew, nsim = 5, threshold = 0.5)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Simulate 5 posterior draws of success probabilities
@@ -161,7 +159,9 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 
 # Simulate 5 draws from posterior Dirichlet distributions at new point
 Xnew <- matrix(seq(-2, 2, length.out = 5), ncol = 1)
@@ -169,7 +169,7 @@ simulate(model, Xnew = Xnew, nsim = 5)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -177,14 +177,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 
 # Simulate 5 draws from posterior Dirichlet distributions at new point

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -68,25 +68,23 @@ m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
 # Fit BKP model
-model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_BKP(X, y, m, Xbounds = Xbounds, theta = 0.04)
 summary(model)
 
 \dontrun{
 # Larger TwinBKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(100, n, replace = TRUE)
 y <- rbinom(n, size = m, prob = true_pi)
 
-# Fit TwinBKP model
+# Fit TwinBKP model using the default global lengthscale tuning
 model <- fit_TwinBKP(
      X, y, m,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 summary(model)
 }
@@ -109,12 +107,14 @@ m <- sample(150, n, replace = TRUE)
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
 # Fit DKP model
-model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.3)
+# A fixed theta is used here only to keep the example fast and reproducible.
+# In practice, omit theta to select it by leave-one-out cross-validation.
+model <- fit_DKP(X, Y, Xbounds = Xbounds, theta = 0.04)
 summary(model)
 
 \dontrun{
 # Larger TwinDKP example
-n <- 200
+n <- 1000
 X <- tgp::lhs(n = n, rect = Xbounds)
 true_pi <- true_pi_fun(X)
 m <- sample(150, n, replace = TRUE)
@@ -122,14 +122,10 @@ m <- sample(150, n, replace = TRUE)
 # Generate multinomial responses
 Y <- t(sapply(1:n, function(i) rmultinom(1, size = m[i], prob = true_pi[i, ])))
 
-# Fit TwinDKP model
+# Fit TwinDKP model using the default global lengthscale tuning
 model <- fit_TwinDKP(
      X, Y,
-     Xbounds = Xbounds,
-     theta_g = 0.3,
-     g = 20,
-     twins = 1,
-     n_threads = 1
+     Xbounds = Xbounds
    )
 summary(model)
 }


### PR DESCRIPTION
### Motivation

- Runnable examples using `theta = 0.3` produced over-smoothed 1D/2D plots; the examples should remain CRAN-safe but visually more representative. 
- Larger Twin examples should demonstrate the default Twin fitting workflow (automatic global tuning) and use realistic large sample sizes in `\dontrun{}` so they are not run on CRAN.

### Description

- Replaced runnable example fixed lengthscales: `theta = 0.3` -> `theta = 0.04` for 1D examples and -> `theta = 0.08` for 2D examples across user-facing roxygen examples in `R/` files and synchronized `man/` files. 
- Added the explanatory roxygen comment immediately before each runnable fit call: `# A fixed theta is used here only to keep the example fast and reproducible.` and `# In practice, omit theta to select it by leave-one-out cross-validation.`
- Updated larger `\dontrun{}` TwinBKP/TwinDKP examples to use `n <- 1000` and to omit `theta_g` (showing the default global tuning workflow) and replaced explicit Twin tuning arguments where appropriate with the default call (keeps expensive tuning inside `\dontrun{}`).
- Regenerated / synchronized the corresponding `man/` `.Rd` examples to reflect the roxygen changes so documentation and examples are consistent; the changes touch many `R/` and `man/` example blocks (user-visible examples only). 

### Testing

- Verified replacements and documentation updates with repository searches such as `rg -n "theta = 0\.04|theta = 0\.08|theta = 0\.3|theta_g = 0\.3|n <- 1000|Fit Twin(BKP|DKP) model using the default" R man` which show the intended `theta` and `n` values in `R/` and `man/` files. 
- Ran `python3` verification scripts to confirm there are no `theta_g =` assignments remaining inside `\dontrun{}` blocks (check passed). 
- Attempted to run the R-based document/test/check commands (`Rscript -e "Rcpp::compileAttributes()"`, `Rscript -e "devtools::document()"`, `Rscript -e "devtools::test()"`, `R CMD build .`, `R CMD check --as-cran BKP_0.3.0.tar.gz`), but these could not be executed in this environment because `R` / `Rscript` are not installed (commands failed with `Rscript: command not found` / `R: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a462964d4f48320be839e0677a8f809)